### PR TITLE
Enhances documentation and shows where ant has to be installed from

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -32,6 +32,14 @@ loklak. With loklak you can do:
 
 - ant (just this, type "ant" - without quotes - and hit enter)
 
+*** I do not have ant installed, How can I install it ?
+
+- Mac OS X Systems
+	- brew update
+	- brew install ant
+
+- Ubuntu
+	- sudo apt-get install ant
 
 *** How do I run loklak?
 


### PR DESCRIPTION
Improves the documentation by telling the users where `ant` has to be installed from.