### PR TITLE
Add /api/validate.json to validate a data source

### DIFF
--- a/src/org/loklak/LoklakServer.java
+++ b/src/org/loklak/LoklakServer.java
@@ -71,6 +71,7 @@ import org.loklak.api.server.StatusServlet;
 import org.loklak.api.server.SuggestServlet;
 import org.loklak.api.server.AccountServlet;
 import org.loklak.api.server.ThreaddumpServlet;
+import org.loklak.api.server.ValidateServlet;
 import org.loklak.api.server.push.FossasiaPushServlet;
 import org.loklak.api.server.push.OpenWifiMapPushServlet;
 import org.loklak.api.server.push.NodelistPushServlet;
@@ -214,6 +215,7 @@ public class LoklakServer {
         servletHandler.addServlet(ProxyServlet.class, "/api/proxy.gif");
         servletHandler.addServlet(ProxyServlet.class, "/api/proxy.png");
         servletHandler.addServlet(ProxyServlet.class, "/api/proxy.jpg");
+        servletHandler.addServlet(ValidateServlet.class, "/api/validate.json");
         ServletHolder pushServletHolder = new ServletHolder(PushServlet.class);
         pushServletHolder.getRegistration().setMultipartConfig(new MultipartConfigElement(tmp.getAbsolutePath()));
         servletHandler.addServlet(pushServletHolder, "/api/push.json");

--- a/src/org/loklak/api/server/ValidateServlet.java
+++ b/src/org/loklak/api/server/ValidateServlet.java
@@ -1,0 +1,138 @@
+/**
+ * ValidateServlet
+ * Copyright 05.08.2015 by Dang Hai An, @zyzo
+ * <p/>
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * <p/>
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * <p/>
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program in the file lgpl21.txt
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.loklak.api.server;
+
+import com.github.fge.jsonschema.core.report.ProcessingReport;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.loklak.api.client.ClientConnection;
+import org.loklak.data.DAO;
+import org.loklak.harvester.JsonValidator;
+import org.loklak.harvester.SourceType;
+
+import javax.servlet.ServletException;
+import javax.servlet.ServletOutputStream;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Map;
+
+public class ValidateServlet extends HttpServlet {
+
+    enum ValidationStatus {
+        offline,
+        invalid,
+        valid
+    }
+
+    @Override
+    protected void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        doGet(request, response);
+    }
+
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        RemoteAccess.Post post = RemoteAccess.evaluate(request);
+        String remoteHash = Integer.toHexString(Math.abs(post.getClientHost().hashCode()));
+
+        // manage DoS
+        if (post.isDoS_blackout()) {
+            response.sendError(503, "your request frequency is too high");
+            return;
+        }
+
+        String url = post.get("url", "");
+        if (url == null || url.length() == 0) {
+            response.sendError(400, "your request does not contain an url to your data object");
+            return;
+        }
+
+        String source_type_str = post.get("source_type", "");
+        if (source_type_str == null || source_type_str.length() == 0) {
+            response.sendError(400, "your request does not contain a source_type parameter");
+            return;
+        }
+        SourceType sourceType;
+        try {
+            sourceType = SourceType.valueOf(source_type_str.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            response.sendError(400, "Invalid source_type parameter : " + source_type_str);
+            return;
+        }
+        JsonValidator.JsonSchemaEnum jsonSchemaEnum;
+        try {
+            jsonSchemaEnum = JsonValidator.JsonSchemaEnum.valueOf(sourceType);
+        } catch (IllegalArgumentException e) {
+            response.sendError(400, "Current version of /api/validate.json doesn't support this source type: " + source_type_str);
+            return;
+        }
+        String callback = post.get("callback", "");
+        boolean jsonp = callback != null && callback.length() > 0;
+
+        ValidationStatus status = null;
+        String message = "";
+
+        Map<String, Object> map;
+
+        boolean offline = false;
+
+        byte[] jsonText = null;
+        try {
+            jsonText = ClientConnection.download(url);
+            map = DAO.jsonMapper.readValue(jsonText, DAO.jsonTypeRef);
+        } catch (Exception e) {
+            message = "Error reading json file from url";
+            status = ValidationStatus.offline;
+            offline = true;
+        }
+
+        if (!offline) {
+            JsonValidator validator = new JsonValidator(jsonSchemaEnum);
+            // validation phase
+            ProcessingReport report = validator.validate(new String(jsonText));
+            if (!report.isSuccess()) {
+                status = ValidationStatus.invalid;
+                message = "json does not conform to schema : " + jsonSchemaEnum.name() + "\n" + report;
+            } else {
+                status = ValidationStatus.valid;
+            }
+        }
+
+        post.setResponse(response, "application/javascript");
+
+        // generate json
+        XContentBuilder json = XContentFactory.jsonBuilder().prettyPrint().lfAtEnd();
+        json.startObject();
+        json.field("status", status.name());
+        if (!(message.length() == 0))
+            json.field("details", message);
+        json.endObject();
+
+        // write json
+        ServletOutputStream sos = response.getOutputStream();
+        if (jsonp) sos.print(callback + "(");
+        sos.print(json.string());
+        if (jsonp) sos.println(");");
+        sos.println();
+
+        DAO.log("Validated url " + url + ". Result = " + status.name());
+    }
+}

--- a/src/org/loklak/harvester/JsonValidator.java
+++ b/src/org/loklak/harvester/JsonValidator.java
@@ -36,16 +36,32 @@ import java.io.IOException;
 public class JsonValidator {
 
     public enum JsonSchemaEnum {
-        FOSSASIA("fossasia.json"),
-        OPENWIFIMAP("openwifimap.json"),
-        NODELIST("nodelist-1.0.1.json"),
-        FREIFUNK_NODE("freifunk-node.json"),
+        FOSSASIA("fossasia.json", SourceType.FOSSASIA_API),
+        OPENWIFIMAP("openwifimap.json", SourceType.OPENWIFIMAP),
+        NODELIST("nodelist-1.0.1.json", SourceType.NODELIST),
+        FREIFUNK_NODE("freifunk-node.json", SourceType.FREIFUNK_NODE),
         ;
         private String filename;
-        JsonSchemaEnum(String filename) {
+        private SourceType sourceType;
+        JsonSchemaEnum(String filename, SourceType sourceType) {
             this.filename = filename;
+            this.sourceType = sourceType;
         }
         public String getFilename() { return filename; }
+
+        public SourceType getSourceType() {
+            return sourceType;
+        }
+
+        public static JsonSchemaEnum valueOf(SourceType sourceType) {
+            for (JsonSchemaEnum schema : JsonSchemaEnum.values()) {
+                if (schema.getSourceType().equals(sourceType)) {
+                    return schema;
+                }
+            }
+            throw new IllegalArgumentException("Invalid sourceType value : " + sourceType);
+        }
+
     }
 
     private JsonSchema schema;


### PR DESCRIPTION
Require two parameters : url and source_type

* url : the url to the source
* source_type : a supported source type string. Some source types exist but aren't supported by the validator, since loklak doesn't store its json schema (or xml/rss schema). In such cases a 400 error is thrown

Fixes #101