### PR TITLE
Fix search by id throwing SearchPhaseExecutionException

### DIFF
--- a/src/org/loklak/data/QueryEntry.java
+++ b/src/org/loklak/data/QueryEntry.java
@@ -696,14 +696,6 @@ public class QueryEntry extends AbstractIndexEntry implements IndexEntry {
                     String[] coord = params.split(",");
                     if (coord.length == 1) {
                         filters.add(FilterBuilders.termsFilter("location_source", coord[0]));
-                    } else if (coord.length == 2) {
-                        double lon = Double.parseDouble(coord[0]);
-                        double lat = Double.parseDouble(coord[1]);
-                        // ugly way to search exact geo_point : using geoboundingboxfilter, with two identical bounding points
-                        // geoshape filter can search for exact point shape but it can't be performed on geo_point field
-                        filters.add(FilterBuilders.geoBoundingBoxFilter("location_point")
-                                .topLeft(lat, lon)
-                                .bottomRight(lat, lon));
                     }
                     else if (coord.length == 4 || coord.length == 5) {
                         double lon_west  = Double.parseDouble(coord[0]);

--- a/src/org/loklak/data/QueryEntry.java
+++ b/src/org/loklak/data/QueryEntry.java
@@ -535,12 +535,7 @@ public class QueryEntry extends AbstractIndexEntry implements IndexEntry {
                     continue;
                 } else if (t.indexOf(':') > 0) {
                     int p = t.indexOf(':');
-                    String key = t.substring(0, p).toLowerCase();
-                    String value = t.substring(p + 1);
-                    String[] terms = value.split(",");
-                    for (String term: terms) {
-                        modifier.put(key, term);
-                    }
+                    modifier.put(t.substring(0, p).toLowerCase(), t.substring(p + 1));
                     continue;
                 } else {
                     // patch characters that will confuse elasticsearch or have a different meaning
@@ -701,6 +696,14 @@ public class QueryEntry extends AbstractIndexEntry implements IndexEntry {
                     String[] coord = params.split(",");
                     if (coord.length == 1) {
                         filters.add(FilterBuilders.termsFilter("location_source", coord[0]));
+                    } else if (coord.length == 2) {
+                        double lon = Double.parseDouble(coord[0]);
+                        double lat = Double.parseDouble(coord[1]);
+                        // ugly way to search exact geo_point : using geoboundingboxfilter, with two identical bounding points
+                        // geoshape filter can search for exact point shape but it can't be performed on geo_point field
+                        filters.add(FilterBuilders.geoBoundingBoxFilter("location_point")
+                                .topLeft(lat, lon)
+                                .bottomRight(lat, lon));
                     }
                     else if (coord.length == 4 || coord.length == 5) {
                         double lon_west  = Double.parseDouble(coord[0]);

--- a/src/org/loklak/data/QueryEntry.java
+++ b/src/org/loklak/data/QueryEntry.java
@@ -535,7 +535,12 @@ public class QueryEntry extends AbstractIndexEntry implements IndexEntry {
                     continue;
                 } else if (t.indexOf(':') > 0) {
                     int p = t.indexOf(':');
-                    modifier.put(t.substring(0, p).toLowerCase(), t.substring(p + 1));
+                    String key = t.substring(0, p).toLowerCase();
+                    String value = t.substring(p + 1);
+                    String[] terms = value.split(",");
+                    for (String term: terms) {
+                        modifier.put(key, term);
+                    }
                     continue;
                 } else {
                     // patch characters that will confuse elasticsearch or have a different meaning
@@ -577,9 +582,9 @@ public class QueryEntry extends AbstractIndexEntry implements IndexEntry {
             
             // apply modifiers
             if (modifier.containsKey("id")) {
-                ops.add(QueryBuilders.termQuery("id_str", modifier.get("id")));
+                ops.add(QueryBuilders.termsQuery("id_str", modifier.get("id")));
             }
-            if (modifier.containsKey("-id")) nops.add(QueryBuilders.termQuery("id_str", modifier.get("-id")));
+            if (modifier.containsKey("-id")) nops.add(QueryBuilders.termsQuery("id_str", modifier.get("-id")));
 
             for (String user: users_positive) {
                 ops.add(QueryBuilders.termQuery("mentions", user));


### PR DESCRIPTION
This PR aims to fix the problem reported in chat: 
```text
@Orbiter I can't perform search by id http://loklak.org/api/search.json?q=id:632002532013834240 (previously worked), any idea ?
The message with id 632002532013834240 does exist http://loklak.org/api/search.json?q=FOSSASIA
local stack trace gives me this
org.elasticsearch.action.search.SearchPhaseExecutionException: Failed to execute phase [query], all shards failed; shardFailures {[szO3d8LWRS63ioD6FSWv8A][messages][0]: SearchParseException[[messages][0]: query[id_str:[],from[0],size[100]: Parse Failure [Failed to parse source [{"from":0,"size":100,"query":{"term":{"id_str":["626616095475113984"]}},"sort":[{"created_at":{"order":"desc"}}]}]]]; nested: ElasticsearchParseException[Expected field name but got END_ARRAY "id_str"]; }{[szO3d8LWRS63ioD6FSWv8A][messages][1]: SearchParseException[[messages][1]: query[id_str:[],from[0],size[100]: Parse Failure [Failed to parse source [{"from":0,"size":100,"query":{"term":{"id_str":["626616095475113984"]}},"sort":[{"created_at":{"order":"desc"}}]}]]]; nested: ElasticsearchParseException[Expected field name but got END_ARRAY "id_str"]; }{[szO3d8LWRS63ioD6FSWv8A][messages][2]: SearchParseException[[messages][2]: query[id_str:[],from[0],size[100]: Parse Failure [Failed to parse source [{"from":0,"size":100,"query":{"term":{"id_str":["626616095475113984"]}},"sort":[{"created_at":{"order":"desc"}}]}]]]; nested: ElasticsearchParseException[Expected field name but got END_ARRAY "id_str"]; }{[szO3d8LWRS63ioD6FSWv8A][messages][3]: SearchParseException[[messages][3]: query[id_str:[],from[0],size[100]: Parse Failure [Failed to parse source [{"from":0,"size":100,"query":{"term":{"id_str":["626616095475113984"]}},"sort":[{"created_at":{"order":"desc"}}]}]]]; nested: ElasticsearchParseException[Expected field name but got END_ARRAY "id_str"]; }{[szO3d8LWRS63ioD6FSWv8A][messages][4]: SearchParseException[[messages][4]: query[id_str:[],from[0],size[100]: Parse Failure [Failed to parse source [{"from":0,"size":100,"query":{"term":{"id_str":["626616095475113984"]}},"sort":[{"created_at":{"order":"desc"}}]}]]]; nested: ElasticsearchParseException[Expected field name but got END_ARRAY "id_str"]; }{[szO3d8LWRS63ioD6FSWv8A][messages][5]: SearchParseException[[messages][5]: query[id_str:[],from[0],size[100]: Parse Failure [Failed to parse source [{"from":0,"size":100,"query":{"term":{"id_str":["626616095475113984"]}},"sort":[{"created_at":{"order":"desc"}}]}]]]; nested: ElasticsearchParseException[Expected field name but got END_ARRAY "id_str"]; }{[szO3d8LWRS63ioD6FSWv8A][messages][6]: SearchParseException[[messages][6]: query[id_str:[],from[0],size[100]: Parse Failure [Failed to parse source [{"from":0,"size":100,"query":{"term":{"id_str":["626616095475113984"]}},"sort":[{"created_at":{"order":"desc"}}]}]]]; nested: ElasticsearchParseException[Expected field name but got END_ARRAY "id_str"]; }{[szO3d8LWRS63ioD6FSWv8A][messages][7]: SearchParseException[[messages][7]: query[id_str:[],from[0],size[100]: Parse Failure [Failed to parse source [{"from":0,"size":100,"query":{"term":{"id_str":["626616095475113984"]}},"sort":[{"created_at":{"order":"desc"}}]}]]]; nested: ElasticsearchParseException[Expected field name but got END_ARRAY "id_str"]; }
    at org.elasticsearch.action.search.type.TransportSearchTypeAction$BaseAsyncAction.onFirstPhaseResult(TransportSearchTypeAction.java:237)
    at org.elasticsearch.action.search.type.TransportSearchTypeAction$BaseAsyncAction$1.onFailure(TransportSearchTypeAction.java:183)
    at org.elasticsearch.search.action.SearchServiceTransportAction$23.run(SearchServiceTransportAction.java:565)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)
    at java.lang.Thread.run(Thread.java:745)
```

The query added is term query but the value is an array, causing parse error.