### PR TITLE
API Documentation spacing fix, /search.json

### DIFF
--- a/html/css/dashboard.css
+++ b/html/css/dashboard.css
@@ -24,7 +24,7 @@ ul.request {
   list-style-type: none;
 }
 .tabcol0 {
-  width:100px;
+  width:130px;
   display:block;
   float:left;
   color: GreenYellow;


### PR DESCRIPTION
Previously
<img width="896" alt="screen shot 2015-10-31 at 1 13 34 pm" src="https://cloud.githubusercontent.com/assets/4545925/10862519/51563b1c-7fd1-11e5-8e11-e20a11adad27.png">

Corrected
<img width="910" alt="screen shot 2015-10-31 at 1 13 23 pm" src="https://cloud.githubusercontent.com/assets/4545925/10862520/5dc0fdba-7fd1-11e5-85c8-a40e22b03547.png">

