### PR TITLE
Edit link : Link was not able to open

### DIFF
--- a/html/api.html
+++ b/html/api.html
@@ -1407,7 +1407,7 @@ added fuzzyness for marker computation
 
 <p>Here is an example :
 <ul class="request">
-	<li><a href="http://localhost:9000/vis/markdown.png?text=hello%20world%0Dhello%20universe&color_text=000000&color_background=ffffff&padding=3">http://localhost:9000/vis/markdown.png?text=hello%20world%0Dhello%20universe&color_text=000000&color_background=ffffff&padding=3</a></li>
+	<li><a href="http://www.loklak.org/vis/markdown.png?text=hello%20world%0Dhello%20universe&color_text=000000&color_background=ffffff&padding=3">http://localhost:9000/vis/markdown.png?text=hello%20world%0Dhello%20universe&color_text=000000&color_background=ffffff&padding=3</a></li>
 </ul><br/>
 </p>
 


### PR DESCRIPTION
After going through api.html page I found this example link at last. When I clicked it was not working here is the image: I removed localhost and putted loklak.org .And then it was working fine showing image [like this] (http://www.loklak.org/vis/markdown.png?text=hello%20world%0Dhello%20universe&color_text=000000&color_background=ffffff&padding=3)
![screenshot from 2016-01-07 22 23 22](https://cloud.githubusercontent.com/assets/9320644/12176573/03bae202-b58e-11e5-8962-b2e4fa4b2228.png)
