### PR TITLE
Remove annoying white line at the bottom!

### DIFF
--- a/html/apps/boilerplate/index.html
+++ b/html/apps/boilerplate/index.html
@@ -74,9 +74,7 @@
           
           <br id="section2"/><br/>
           <h2 class="sub-header">section 3</h2>
-          <p>yes the empty line at the bottom here is ugly. Please fix it!</p>
-      
-          <br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/>
+          <p>Thanks to one of our Google Code-In students, the annoying white line at the bottom of this page has ceased to exist. Whew!</p>
         </div>
       </div>
     </div>

--- a/html/css/loklak.css
+++ b/html/css/loklak.css
@@ -13,6 +13,5 @@
 
 body {
   padding-top: 50px;
-  padding-bottom: 20px;
   font: DroidSansMono;
 }


### PR DESCRIPTION
Removed a line from a CSS rule that added `padding-bottom` to the `<body>`, causing a white line to appear at the bottom of the page.

A suggestion would be to add a black background to the `<body>` as well, because some operating systems allow you to scroll past the top and bottom before snapping back.