### PR TITLE
Heroku deploy

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: sh bin/heroku_start.sh

--- a/bin/heroku_start.sh
+++ b/bin/heroku_start.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env sh
+cd `dirname $0`/..
+mkdir -p data
+
+DFAULTCONFIG="conf/config.properties"
+CUSTOMCONFIG="data/settings/customized_config.properties"
+DFAULTXmx="-Xmx800m";
+CUSTOMXmx=""
+if [ -f $DFAULTCONFIG ]; then
+ j="`grep Xmx $DFAULTCONFIG | sed 's/^[^=]*=//'`";
+ if [ -n $j ]; then DFAULTXmx="$j"; fi;
+fi
+if [ -f $CUSTOMCONFIG ]; then
+ j="`grep Xmx $CUSTOMCONFIG | sed 's/^[^=]*=//'`";
+ if [ -n $j ]; then CUSTOMXmx="$j"; fi;
+fi
+
+#echo "DFAULTXmx: !$DFAULTXmx!"
+#echo "CUSTOMXmx: !$CUSTOMXmx!"
+
+CLASSPATH=""
+for N in lib/*.jar; do CLASSPATH="$CLASSPATH$N:"; done
+CLASSPATH=".:./classes/:$CLASSPATH"
+
+cmdline="java";
+
+if [ -n "$CUSTOMXmx" ]; then cmdline="$cmdline -Xmx$CUSTOMXmx";
+elif [ -n "$DFAULTXmx" ]; then cmdline="$cmdline -Xmx$DFAULTXmx";
+fi
+
+echo "starting loklak"
+
+cmdline="$cmdline -server -classpath $CLASSPATH org.loklak.LoklakServer";
+
+eval $cmdline
+#echo $cmdline;
+
+echo "loklak server started at port 9000, open your browser at http://localhost:9000"

--- a/installation_heroku.md
+++ b/installation_heroku.md
@@ -1,0 +1,12 @@
+#How to run the Loklak server on Heroku
+
+1. Create a Heroku account https://www.heroku.com/
+2. Download the Heroku toolbelt https://toolbelt.heroku.com/
+3. Login with heroku: `heroku login`
+4. Clone the Loklak server (if not already) : `git clone https://github.com/loklak/loklak_server.git`
+5. Create a heroku app: `heroku create`
+6. Set the buildpack: `heroku buildpacks:set https://github.com/aneeshd16/heroku-buildpack-ant-loklak.git`
+7. Push your app to heroku: `git push heroku master`
+8. Confirm the loklak server is running: `heroku logs --tail`
+9. Sometimes the server may take a while to start. The logs would show `State changed from starting to up` when the server is ready.
+9. Open the URL of your server in your browser: `heroku open`.

--- a/src/org/loklak/LoklakServer.java
+++ b/src/org/loklak/LoklakServer.java
@@ -135,6 +135,10 @@ public class LoklakServer {
         // check if a loklak service is already running on configured port
         String httpPortS = config.get("port.http");
         int httpPort = httpPortS == null ? 9000 : Integer.parseInt(httpPortS);
+        Map<String, String> env = System.getenv();
+        if(env.containsKey("PORT")) {
+            httpPort = Integer.parseInt(env.get("PORT"));
+        }
         ServerSocket ss = null;
         try {
             ss = new ServerSocket(httpPort);


### PR DESCRIPTION
This PR adds a few changes to enable the deployment of Loklak server to Heroku.

1. LoklakServer.java (Please review): Added a conditional to check if the environment variable `PORT` is present. The server will be started with this port instead of 9000 or the port in config.properties. Heroku internally assigns a port to the app, and the app is expected to use this port for web deployment.
2. heroku_start.sh: Changed the process into a foreground one as Heroku requires foreground processes only. Also changed logging to stdout so that logs are visible in heroku logs.
3. Procfile: Defines the task to start. Required for deployment.
4. installation_heroku.md: Documentation for deploying to heroku

## Important
For testing this PR, instead of `git push heroku master`, you need to do `git push heroku heroku-deploy:master`