### PR TITLE
[Heroku_Installation_Guide] Minor change in setting buildpack & creating app with customized name

### DIFF
--- a/installation_heroku.md
+++ b/installation_heroku.md
@@ -4,7 +4,7 @@
 2. Download the Heroku toolbelt https://toolbelt.heroku.com/
 3. Login with heroku: `heroku login`
 4. Clone the Loklak server (if not already) : `git clone https://github.com/loklak/loklak_server.git`
-5. Create a heroku app: `heroku create`
+5. Create a heroku app: `heroku create`<br> To creat an app with customized name, use `heroku create --app <your_app_name>` where the app name must start with a letter and can only contain lowercase letters, numbers, and dashes.
 6. Set the buildpack. <br>Option 1: `cd` into the app folder and run `heroku buildpacks:set https://github.com/aneeshd16/heroku-buildpack-ant-loklak.git`<br>Option 2: Run `heroku buildpacks:set https://github.com/aneeshd16/heroku-buildpack-ant-loklak.git --app <your_app_name>`
 7. Push your app to heroku: `git push heroku master`
 8. Confirm the loklak server is running: `heroku logs --tail`

--- a/installation_heroku.md
+++ b/installation_heroku.md
@@ -5,7 +5,7 @@
 3. Login with heroku: `heroku login`
 4. Clone the Loklak server (if not already) : `git clone https://github.com/loklak/loklak_server.git`
 5. Create a heroku app: `heroku create`
-6. Set the buildpack: `heroku buildpacks:set https://github.com/aneeshd16/heroku-buildpack-ant-loklak.git`
+6. Set the buildpack. <br>Option 1: `cd` into the app folder and run `heroku buildpacks:set https://github.com/aneeshd16/heroku-buildpack-ant-loklak.git`<br>Option 2: Run `heroku buildpacks:set https://github.com/aneeshd16/heroku-buildpack-ant-loklak.git --app <your_app_name>`
 7. Push your app to heroku: `git push heroku master`
 8. Confirm the loklak server is running: `heroku logs --tail`
 9. Sometimes the server may take a while to start. The logs would show `State changed from starting to up` when the server is ready.


### PR DESCRIPTION
While setting the buildpack as mentioned in *Step 6* of the guide, it rather should be `heroku buildpacks:set https://github.com/aneeshd16/heroku-buildpack-ant-loklak.git --app <app-name>` instead of just `heroku buildpacks:set https://github.com/aneeshd16/heroku-buildpack-ant-loklak.git` as it gives an error on running that command without mentioning the app or cd-ing into the app-folder.