### PR TITLE
Fixed Bluemix Deployment

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -1,9 +1,8 @@
----
-  name: "Loklak Server"
+--- 
+- name: "Loklak Server"
+  buildpack: "https://github.com/aneeshd16/heroku-buildpack-ant-loklak.git"
   description: "Distributed Tweet Search Server"
-  logo: "https://raw.githubusercontent.com/loklak/loklak_server/master/html/images/loklak_anonymous.png"
-  website: "http://loklak.org"
-  repository: "https://github.com/loklak/loklak_server.git"
   image: "mariobehling/loklak"
-  env: 
-    BUILDPACK_URL: "https://github.com/aneeshd16/heroku-buildpack-ant-loklak.git"
+  logo: "https://raw.githubusercontent.com/loklak/loklak_server/master/html/images/loklak_anonymous.png"
+  repository: "https://github.com/loklak/loklak_server.git"
+  website: "http://loklak.org"


### PR DESCRIPTION
I checked the Bluemix docs, and so far I've figured this out:

1. The buildpack url doesn't go into the env of the manifest.yml, [it has to be specified separately](https://console.ng.bluemix.net/docs/manageapps/depapps.html) as ```buildpack: BUILDPACK_URL```. So I don't think the deployment is even noticing the buildpack right now. I checked the format from [here](https://console.ng.bluemix.net/docs/manageapps/depapps.html#appmanifest)

2. Probably pipeline.yml is needed because the app uses containers.

I added the blocked label. @sudheesh001 @jig08 @Orbiter @daminisatya how do I test it?

PS: Did the assignment by mistake, sorry. 