### PR TITLE
Exposing port 443 to make Docker Cloud deployment endpoint public

### DIFF
--- a/docker-cloud.yml
+++ b/docker-cloud.yml
@@ -3,3 +3,4 @@ web:
   image: mariobehling/loklak
   ports:
     - "80"
+    - "443"


### PR DESCRIPTION
Follow up from PR #328 
***
Now we have `dynamic->80/tcp` and `dynamic->443/tcp` as defined by service.
