### PR TITLE
Fixed Boilerplate

### DIFF
--- a/html/apps/boilerplate/index.html
+++ b/html/apps/boilerplate/index.html
@@ -7,20 +7,20 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="Content-Language" content="en, english"/>
     <meta name="author" content="@0rb1t3r"> <!-- CHANGE THIS -->
-    <link rel="icon" type="image/png" href="/artwork/favicon.png">
+    <link rel="icon" type="image/png" href="../../artwork/favicon.png">
     <title>loklak.org - Apps Boilerplate</title> <!-- CHANGE THIS -->
       
-    <link href="/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/css/dashboard.css" rel="stylesheet">
-    <link href="/css/loklak.css" rel="stylesheet">
+    <link href="../../css/bootstrap.min.css" rel="stylesheet">
+    <link href="../../css/dashboard.css" rel="stylesheet">
+    <link href="../../css/loklak.css" rel="stylesheet">
 
     <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
     <!--[if lt IE 9]>
-      <script src="/js/html5shiv.min.js"></script>
-      <script src="/js/respond.min.js"></script>
+      <script src="../../js/html5shiv.min.js"></script>
+      <script src="../../js/respond.min.js"></script>
     <![endif]-->
     
-    <script src="/js/angular.min.js"></script>
+    <script src="../../js/angular.min.js"></script>
   </head>
 
   <body>
@@ -34,17 +34,17 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
           </button>
-          <a class="navbar-brand" href="http://loklak.org"><img src="/images/loklak_org.png" height="24" style="float:left;">: App Boilerplate</a>
+          <a class="navbar-brand" href="http://loklak.org"><img src="../../images/loklak_org.png" height="24" style="float:left;">: App Boilerplate</a>
         </div>
         <div id="navbar" class="navbar-collapse collapse">
           <ul class="nav navbar-nav navbar-right">
-            <li><a href="/index.html">Home</a></li>
-            <li><a href="/about.html">About</a></li>
-            <li><a href="/architecture.html">Architecture</a></li>
-            <li><a href="/download.html">Download</a></li>
-            <li><a href="/api.html">API</a></li>
-            <li><a href="/dump.html">Dumps</a></li>
-            <li><a href="/apps/">Apps</a></li>
+            <li><a href="../../index.html">Home</a></li>
+            <li><a href="../../about.html">About</a></li>
+            <li><a href="../../architecture.html">Architecture</a></li>
+            <li><a href="../../download.html">Download</a></li>
+            <li><a href="../../api.html">API</a></li>
+            <li><a href="../../dump.html">Dumps</a></li>
+            <li><a href="../../apps/">Apps</a></li>
           </ul>
         </div>
       </div>
@@ -82,9 +82,9 @@
     <!-- Bootstrap core JavaScript
     ================================================== -->
     <!-- Placed at the end of the document so the pages load faster -->
-    <script src="/js/jquery.min.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
+    <script src="../../js/jquery.min.js"></script>
+    <script src="../../js/bootstrap.min.js"></script>
     <!-- IE10 viewport hack for Surface/desktop Windows 8 bug -->
-    <script src="/js/ie10-viewport-bug-workaround.js"></script>
+    <script src="../../js/ie10-viewport-bug-workaround.js"></script>
   </body>
 </html>


### PR DESCRIPTION
The boilerplate index.html as of now does not work. The sections in the menu, on clicking, don't lead anywhere and the theme (css) was not applying (it was all whitespace). This was because the directories used in the index.html (i.e the css, js, images directories etc) were not being referred to (boilerplate is in ```html/apps/boilerplate/index.html``` and css is in ```html/css``` so you can't simply refer to css using /css/loklak.css, it was not working). The path to those files in ```boilerplate/index.html``` is incorrect. It is fixed by adding ```../..```. 

@Orbiter I'm not sure if this is necessary as a commit, but I figured out this is why I could not use the boilerplate earlier, because the right files were not being referred to. I have fixed it. You don't need to copy any files from the CSS / JS directories to the new app directories now, you can simply copy the boilerplate and the default theme will come. This is the result of the commit:

<img width="1280" alt="screen shot 2016-05-18 at 7 58 04 pm" src="https://cloud.githubusercontent.com/assets/14081800/15362612/6fabdd9c-1d33-11e6-8433-1f2da54e4c52.png">
