### PR TITLE
Regex fixes for text, links, mention fields for search.json, & added spaces before links

### DIFF
--- a/src/org/loklak/harvester/TwitterScraper.java
+++ b/src/org/loklak/harvester/TwitterScraper.java
@@ -367,10 +367,10 @@ public class TwitterScraper {
     }
     
 
-    final static Pattern hashtag_pattern = Pattern.compile("<a .*?href=\"(.*?)\".*?class=\"twitter-hashtag.*?\".*?><s>#</s><b>(.*?)</b></a>");
-    final static Pattern timeline_link_pattern = Pattern.compile("<a .*?href=\"(.*?)\".*?data-expanded-url=\"(.*?)\".*?twitter-timeline-link.*?title=\"(.*?)\".*?>.*?</a>");
-    final static Pattern timeline_embed_pattern = Pattern.compile("<a .*?href=\"(.*?)\".*?twitter-timeline-link.*?>pic.twitter.com/(.*?)</a>");
-    final static Pattern emoji_pattern = Pattern.compile("<img .*?class=\"twitter-emoji\".*?alt=\"(.*?)\".*?>");
+    final static Pattern hashtag_pattern = Pattern.compile("<a href=\"/hashtag/.*?\".*?class=\"twitter-hashtag.*?\".*?><s>#</s><b>(.*?)</b></a>");
+    final static Pattern timeline_link_pattern = Pattern.compile("<a href=\"https://(.*?)\".*? data-expanded-url=\"(.*?)\".*?twitter-timeline-link.*?title=\"(.*?)\".*?>.*?</a>");
+    final static Pattern timeline_embed_pattern = Pattern.compile("<a href=\"(https://t.co/\\w+)\" class=\"twitter-timeline-link.*?>pic.twitter.com/(.*?)</a>");
+    final static Pattern emoji_pattern = Pattern.compile("<img .*?class=\"Emoji Emoji--forText\".*?alt=\"(.*?)\".*?>");
     final static Pattern doublespace_pattern = Pattern.compile("  ");
     final static Pattern cleanup_pattern = Pattern.compile(
         "</?(s|b|strong)>|" +
@@ -499,7 +499,7 @@ public class TwitterScraper {
             try {
                 Matcher m = hashtag_pattern.matcher(text);
                 if (m.find()) {
-                    text = m.replaceFirst(" #" + m.group(2) + " "); // the extra spaces are needed because twitter removes them if the hashtag is followed with a link
+                    text = m.replaceFirst(" #" + m.group(1) + " "); // the extra spaces are needed because twitter removes them if the hashtag is followed with a link
                     continue;
                 }
             } catch (Throwable e) {
@@ -510,7 +510,7 @@ public class TwitterScraper {
                 Matcher m = timeline_link_pattern.matcher(text);
                 if (m.find()) {
                     String expanded = RedirectUnshortener.unShorten(m.group(2));
-                    text = m.replaceFirst(expanded);
+                    text = m.replaceFirst(" " + expanded);
                     continue;
                 }
             } catch (Throwable e) {
@@ -521,7 +521,7 @@ public class TwitterScraper {
                 Matcher m = timeline_embed_pattern.matcher(text);
                 if (m.find()) {
                     String shorturl = RedirectUnshortener.unShorten(m.group(2));
-                    text = m.replaceFirst("https://pic.twitter.com/" + shorturl + " ");
+                    text = m.replaceFirst(" https://pic.twitter.com/" + shorturl + " ");
                     continue;
                 }
             } catch (Throwable e) {

--- a/src/org/loklak/objects/MessageEntry.java
+++ b/src/org/loklak/objects/MessageEntry.java
@@ -416,7 +416,7 @@ public class MessageEntry extends AbstractObjectEntry implements ObjectEntry {
     }
     
     final static Pattern SPACEX_PATTERN = Pattern.compile("  +"); // two or more
-    final static Pattern URL_PATTERN = Pattern.compile("(?:\\b|^)(https?://.*?)(?:[) ]|$)"); // right boundary must be space since others may appear in urls
+    final static Pattern URL_PATTERN = Pattern.compile("(?:\\b|^)(https?://[-A-Za-z0-9+&@#/%?=~_()|!:,.;]*[-A-Za-z0-9+&@#/%=~_()|])"); // right boundary must be space or ) since others may appear in urls
     final static Pattern USER_PATTERN = Pattern.compile("(?:[ (]|^)(@..*?)(?:\\b|$)"); // left boundary must be space since the @ is itself a boundary
     final static Pattern HASHTAG_PATTERN = Pattern.compile("(?:[ (]|^)(#..*?)(?:\\b|$)"); // left boundary must be a space since the # is itself a boundary
 


### PR DESCRIPTION
#348 occurs because of the scraper regex pattern, which replaces previous tags, so for eg when there is an uploaded photo or link, the mention is removed before it can be extracted as it has the anchor tag also. Adding a space before uploaded photo url in the text field will allow it to be extracted into the links field.