### PR TITLE
Add optional save http-client download

### DIFF
--- a/conf/config.properties
+++ b/conf/config.properties
@@ -7,6 +7,9 @@
 port.http=9000
 port.https=9443
 
+# allow TLS connections with invalid certificates
+httpsclient.trustall=true
+
 # require http auth (true/false)
 http.auth=false
 

--- a/src/org/loklak/http/TrustAllHostNameVerifier.java
+++ b/src/org/loklak/http/TrustAllHostNameVerifier.java
@@ -1,0 +1,11 @@
+package org.loklak.http;
+
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLSession;
+
+public class TrustAllHostNameVerifier implements HostnameVerifier {
+
+	public boolean verify(String hostname, SSLSession session) {
+		return true;
+	}
+}


### PR DESCRIPTION
This is actually a dublicate of #366, but all in one commit.
It add an option to enable certificate checking on https downloads, but is not on by default.
Also removes deprecated code and simplifies everything a bit