### PR TITLE
Updated buildpack URLs after naming convention changes

### DIFF
--- a/app.json
+++ b/app.json
@@ -6,6 +6,6 @@
 	"repository": "https://github.com/loklak/loklak_server.git",
 	"image": "mariobehling/loklak",
 	"env": {
-		"BUILDPACK_URL": "https://github.com/aneeshd16/heroku-buildpack-ant-loklak.git"
+		"BUILDPACK_URL": "https://github.com/loklak/heroku_buildpack_ant_loklak.git"
 	}
 }

--- a/installation_heroku.md
+++ b/installation_heroku.md
@@ -6,7 +6,7 @@
 4. Clone the Loklak server (if not already) : `git clone https://github.com/loklak/loklak_server.git`
 5. Move into the cloned repository: `cd loklak_server`
 6. Create a heroku app: `heroku create`
-7. Set the buildpack: `heroku buildpacks:set https://github.com/aneeshd16/heroku-buildpack-ant-loklak.git`
+7. Set the buildpack: `heroku buildpacks:set https://github.com/loklak/heroku_buildpack_ant_loklak.git`
 8. Push your app to heroku: `git push heroku master`
 9. Confirm the loklak server is running: `heroku logs --tail`
 10. Sometimes the server may take a while to start. The logs would show `State changed from starting to up` when the server is ready.

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,7 +1,7 @@
 --- 
 applications:
 - name: "Loklak Server"
-  buildpack: "https://github.com/leonmak/bluemix-buildpack-ant-loklak.git"
+  buildpack: "https://github.com/loklak/bluemix_buildpack_ant_loklak.git"
   description: "Distributed Tweet Search Server"
   image: "mariobehling/loklak"
   logo: "https://raw.githubusercontent.com/loklak/loklak_server/master/html/images/loklak_anonymous.png"

--- a/scalingo.json
+++ b/scalingo.json
@@ -7,7 +7,7 @@
 	"image": "mariobehling/loklak",
 	"env": {
 		"BUILDPACK_URL": {
-			"value": "https://github.com/aneeshd16/heroku-buildpack-ant-loklak.git"
+			"value": "https://github.com/loklak/heroku_buildpack_ant_loklak.git"
 		}
 	}
 }


### PR DESCRIPTION
Test the following
- [ ] Heroku deploy
- [ ] Bluemix deploy
- [ ] Scalingo deploy

URLs have been changed for buildpacks from `aneeshd16/heroku-buildpack-ant-loklak` to `loklak/heroku_buildpack_ant_loklak` and similarly for bluemix for `leonmak/bluemix-buildpack-ant-loklak` to `loklak/bluemix_buildpack_ant_loklak`