### PR TITLE
Edited regex for twitter scraper, and input text

### DIFF
--- a/src/org/loklak/harvester/TwitterScraper.java
+++ b/src/org/loklak/harvester/TwitterScraper.java
@@ -221,6 +221,10 @@ public class TwitterScraper {
                 continue;
             }
             if ((p = input.indexOf("class=\"TweetTextSize")) > 0) {
+                // read until closing p tag to account for new lines in tweets
+                while (input.lastIndexOf("</p>") == -1){
+                  input = input + ' ' + br.readLine();
+                }
                 prop tweettext = new prop(input, p, null);
                 props.put("tweettext", tweettext);
                 continue;
@@ -367,10 +371,10 @@ public class TwitterScraper {
     }
     
 
-    final static Pattern hashtag_pattern = Pattern.compile("<a .*?href=\"(.*?)\".*?class=\"twitter-hashtag.*?\".*?><s>#</s><b>(.*?)</b></a>");
-    final static Pattern timeline_link_pattern = Pattern.compile("<a .*?href=\"(.*?)\".*?data-expanded-url=\"(.*?)\".*?twitter-timeline-link.*?title=\"(.*?)\".*?>.*?</a>");
-    final static Pattern timeline_embed_pattern = Pattern.compile("<a .*?href=\"(.*?)\".*?twitter-timeline-link.*?>pic.twitter.com/(.*?)</a>");
-    final static Pattern emoji_pattern = Pattern.compile("<img .*?class=\"twitter-emoji\".*?alt=\"(.*?)\".*?>");
+    final static Pattern hashtag_pattern = Pattern.compile("<a href=\"/hashtag/.*?\".*?class=\"twitter-hashtag.*?\".*?><s>#</s><b>(.*?)</b></a>");
+    final static Pattern timeline_link_pattern = Pattern.compile("<a href=\"https://(.*?)\".*? data-expanded-url=\"(.*?)\".*?twitter-timeline-link.*?title=\"(.*?)\".*?>.*?</a>");
+    final static Pattern timeline_embed_pattern = Pattern.compile("<a href=\"(https://t.co/\\w+)\" class=\"twitter-timeline-link.*?>pic.twitter.com/(.*?)</a>");
+    final static Pattern emoji_pattern = Pattern.compile("<img .*?class=\"Emoji Emoji--forText\".*?alt=\"(.*?)\".*?>");
     final static Pattern doublespace_pattern = Pattern.compile("  ");
     final static Pattern cleanup_pattern = Pattern.compile(
         "</?(s|b|strong)>|" +
@@ -499,7 +503,7 @@ public class TwitterScraper {
             try {
                 Matcher m = hashtag_pattern.matcher(text);
                 if (m.find()) {
-                    text = m.replaceFirst(" #" + m.group(2) + " "); // the extra spaces are needed because twitter removes them if the hashtag is followed with a link
+                    text = m.replaceFirst(" #" + m.group(1) + " "); // the extra spaces are needed because twitter removes them if the hashtag is followed with a link
                     continue;
                 }
             } catch (Throwable e) {
@@ -510,7 +514,7 @@ public class TwitterScraper {
                 Matcher m = timeline_link_pattern.matcher(text);
                 if (m.find()) {
                     String expanded = RedirectUnshortener.unShorten(m.group(2));
-                    text = m.replaceFirst(expanded);
+                    text = m.replaceFirst(" " + expanded);
                     continue;
                 }
             } catch (Throwable e) {
@@ -521,7 +525,7 @@ public class TwitterScraper {
                 Matcher m = timeline_embed_pattern.matcher(text);
                 if (m.find()) {
                     String shorturl = RedirectUnshortener.unShorten(m.group(2));
-                    text = m.replaceFirst("https://pic.twitter.com/" + shorturl + " ");
+                    text = m.replaceFirst(" https://pic.twitter.com/" + shorturl + " ");
                     continue;
                 }
             } catch (Throwable e) {

--- a/src/org/loklak/objects/MessageEntry.java
+++ b/src/org/loklak/objects/MessageEntry.java
@@ -416,7 +416,7 @@ public class MessageEntry extends AbstractObjectEntry implements ObjectEntry {
     }
     
     final static Pattern SPACEX_PATTERN = Pattern.compile("  +"); // two or more
-    final static Pattern URL_PATTERN = Pattern.compile("(?:\\b|^)(https?://.*?)(?:[) ]|$)"); // right boundary must be space since others may appear in urls
+    final static Pattern URL_PATTERN = Pattern.compile("(?:\\b|^)(https?://[-A-Za-z0-9+&@#/%?=~_()|!:,.;]*[-A-Za-z0-9+&@#/%=~_()|])"); // right boundary must be space or ) since others may appear in urls
     final static Pattern USER_PATTERN = Pattern.compile("(?:[ (]|^)(@..*?)(?:\\b|$)"); // left boundary must be space since the @ is itself a boundary
     final static Pattern HASHTAG_PATTERN = Pattern.compile("(?:[ (]|^)(#..*?)(?:\\b|$)"); // left boundary must be a space since the # is itself a boundary
 


### PR DESCRIPTION
Solves the problems of regex overlapping hashtags, links, pictures and emoji due to tags,

- Emojis:
![screenshot 2016-05-28 01 47 07](https://cloud.githubusercontent.com/assets/13071508/15617369/3d0b015c-247b-11e6-8aba-d4a0da135f19.png)
![screenshot 2016-05-28 01 47 23](https://cloud.githubusercontent.com/assets/13071508/15617371/425f0108-247b-11e6-978a-60bf4967af93.png)
- After fix
![screenshot 2016-05-28 02 07 06](https://cloud.githubusercontent.com/assets/13071508/15617535/f6bfe54a-247b-11e6-9eb9-01742f11b3bf.png)

- Links joined:
![screenshot 2016-05-28 01 49 28](https://cloud.githubusercontent.com/assets/13071508/15617396/5f7f7bf0-247b-11e6-9d80-9824595c2fe4.png)
![screenshot 2016-05-28 01 49 36](https://cloud.githubusercontent.com/assets/13071508/15617402/69206796-247b-11e6-9bd7-1d7110e363b5.png)
![screenshot 2016-05-28 01 51 11](https://cloud.githubusercontent.com/assets/13071508/15617743/db51f1c6-247c-11e6-9c89-0a7b2230e79a.png)

- After fix
![screenshot 2016-05-28 02 07 28](https://cloud.githubusercontent.com/assets/13071508/15617558/1063127e-247c-11e6-8eff-0b2194750154.png)
![screenshot 2016-05-28 02 31 21](https://cloud.githubusercontent.com/assets/13071508/15617748/e047f05e-247c-11e6-9240-461e166089a7.png)

- Spacing for Pictures:
![screenshot 2016-05-28 01 57 13](https://cloud.githubusercontent.com/assets/13071508/15617638/71f5cc0c-247c-11e6-8e0c-c057aea3e662.png)
![screenshot 2016-05-28 01 57 24](https://cloud.githubusercontent.com/assets/13071508/15617654/86026552-247c-11e6-8f21-ba659b4b20d3.png)
- after fix
![screenshot 2016-05-28 02 33 47](https://cloud.githubusercontent.com/assets/13071508/15617675/a3787518-247c-11e6-8310-19bcf9a34a17.png)

- Fixes #348, @user disappears
![screenshot 2016-05-28 02 48 44](https://cloud.githubusercontent.com/assets/13071508/15618133/fb32900c-247e-11e6-9162-7184f185649f.png)
![screenshot 2016-05-28 02 48 33](https://cloud.githubusercontent.com/assets/13071508/15618136/007c327a-247f-11e6-9504-bd46114003bd.png)
- after fix
![screenshot 2016-05-28 02 50 12](https://cloud.githubusercontent.com/assets/13071508/15618139/05025dd8-247f-11e6-8ed3-c86e14733071.png)

- br.readline() doesn't work for multiple-line tweets
![screenshot 2016-05-28 02 21 28](https://cloud.githubusercontent.com/assets/13071508/15618157/14c36546-247f-11e6-85c0-9b571f328610.png)
![screenshot 2016-05-28 02 21 34](https://cloud.githubusercontent.com/assets/13071508/15618159/1759519e-247f-11e6-8812-92b78961ea21.png)
- after fix
![screenshot 2016-05-28 02 21 51](https://cloud.githubusercontent.com/assets/13071508/15618165/1c33a73c-247f-11e6-922d-8eee883a4fa7.png)

- links ending with ')'
![screenshot 2016-05-17 19 25 45](https://cloud.githubusercontent.com/assets/13071508/15618318/fab1f946-247f-11e6-9263-c074323f75e8.png)
![screenshot 2016-05-28 02 57 02](https://cloud.githubusercontent.com/assets/13071508/15618323/00e007ae-2480-11e6-9164-c9a3cf7279d8.png)
- after fix
![screenshot 2016-05-28 02 57 25](https://cloud.githubusercontent.com/assets/13071508/15618324/039131bc-2480-11e6-9b37-468e0f4b9e36.png)
