### PR TITLE
Cleanup thread for AAA files

### DIFF
--- a/src/org/loklak/data/DAO.java
+++ b/src/org/loklak/data/DAO.java
@@ -75,6 +75,7 @@ import org.loklak.tools.DateParser;
 import org.loklak.tools.OS;
 import org.loklak.tools.storage.JsonDataset;
 import org.loklak.tools.storage.JsonFile;
+import org.loklak.tools.storage.JsonFileAAA;
 import org.loklak.tools.storage.JsonReader;
 import org.loklak.tools.storage.JsonRepository;
 import org.loklak.tools.storage.JsonStreamReader;
@@ -141,7 +142,7 @@ public class DAO {
     public static Peers peers = new Peers();
     
     // AAA Schema for server usage
-    public static JsonFile authentication;
+    public static JsonFileAAA authentication;
     public static JsonFile authorization;
     public static JsonFile accounting_persistent;
     public static Map<String, Accounting> accounting_temporary = new HashMap<>();
@@ -221,7 +222,7 @@ public class DAO {
         Path settings_dir = dataPath.resolve("settings");
         settings_dir.toFile().mkdirs();
         Path authentication_path = settings_dir.resolve("authentication.json");
-        authentication = new JsonFile(authentication_path.toFile());
+        authentication = new JsonFileAAA(authentication_path.toFile());
         OS.protectPath(authentication_path);
         Path authorization_path = settings_dir.resolve("authorization.json");
         authorization = new JsonFile(authorization_path.toFile());

--- a/src/org/loklak/server/AbstractAPIHandler.java
+++ b/src/org/loklak/server/AbstractAPIHandler.java
@@ -48,6 +48,7 @@ public abstract class AbstractAPIHandler extends HttpServlet implements APIHandl
     private String[] serverProtocolHostStub = null;
     private static Long defaultCookieTime = (long) (60 * 60 * 24 * 7);
     private static Long defaultAnonymousTime = (long) (60 * 60 * 24);
+    private static final String expire_string = "expires_on";
 
     public AbstractAPIHandler() {
         this.serverProtocolHostStub = null;
@@ -283,7 +284,7 @@ public abstract class AbstractAPIHandler extends HttpServlet implements APIHandl
 	            				ClientCredential cookieCredential = new ClientCredential(ClientCredential.Type.cookie, loginToken);
 	            				JSONObject user_obj = new JSONObject();
 	            				user_obj.put("id",identity.toString());
-	            				user_obj.put("expires_on", Instant.now().getEpochSecond() + defaultCookieTime);
+	            				user_obj.put(expire_string, Instant.now().getEpochSecond() + defaultCookieTime);
 	            				DAO.authentication.put(cookieCredential.toString(), user_obj);
 	        	    			
 	            				response.addCookie(loginCookie);
@@ -337,7 +338,7 @@ public abstract class AbstractAPIHandler extends HttpServlet implements APIHandl
         else{
         	authentication_obj = new JSONObject();
         }
-        authentication_obj.put("expires_on", Instant.now().getEpochSecond() + defaultAnonymousTime);
+        authentication_obj.put(expire_string, Instant.now().getEpochSecond() + defaultAnonymousTime);
     	
         DAO.authentication.put(credential.toString(), authentication_obj);
         return new ClientIdentity(credential.toString());

--- a/src/org/loklak/server/Authentication.java
+++ b/src/org/loklak/server/Authentication.java
@@ -31,6 +31,7 @@ public class Authentication {
 
     private JsonFile parent;
     private JSONObject json;
+    private static final String expire_string = "expires_on";
 
     /**
      * create a new authentication object. The given json object must be taken
@@ -56,12 +57,12 @@ public class Authentication {
     }
 
     public void setExpireTime(long time){
-    	this.json.put("expires_on", Instant.now().getEpochSecond() + time);
+    	this.json.put(expire_string, Instant.now().getEpochSecond() + time);
     	if (this.parent != null) this.parent.commit();
     }
     
     public boolean checkExpireTime(){
-    	if(this.json.has("expires_on") && this.json.getLong("expires_on") > Instant.now().getEpochSecond()) return true;
+    	if(this.json.has(expire_string) && this.json.getLong(expire_string) > Instant.now().getEpochSecond()) return true;
     	return false;
     }
 }

--- a/src/org/loklak/server/Authorization.java
+++ b/src/org/loklak/server/Authorization.java
@@ -19,7 +19,6 @@
 
 package org.loklak.server;
 
-import org.json.JSONArray;
 import org.json.JSONObject;
 import org.loklak.tools.storage.JsonFile;
 

--- a/src/org/loklak/tools/storage/DatabaseCleanupThread.java
+++ b/src/org/loklak/tools/storage/DatabaseCleanupThread.java
@@ -1,0 +1,60 @@
+/**
+ *  DatabaseCleanupThread
+ *  Copyright 03.06.2016 by Robert Mader, @treba123
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *  
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *  
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program in the file lgpl21.txt
+ *  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.loklak.tools.storage;
+
+import org.eclipse.jetty.util.log.Log;
+
+
+/**
+ * This thread calls a cleanup function on a set of JsonFileAAA
+ *
+ */
+public class DatabaseCleanupThread extends Thread {
+	
+	private boolean shallRun = true;
+	private JsonFileAAA[] files;
+	
+	public DatabaseCleanupThread(JsonFileAAA[] files){
+		this.files = files;
+	}
+	
+	/**
+     * ask the thread to shut down
+     */
+    public void shutdown() {
+    	this.shallRun = false;
+        this.interrupt();
+        Log.getLog().info("catched database cleanup termination signal");
+    }
+    
+    @Override
+    public void run() {
+    	while(this.shallRun) try{
+    		for(JsonFileAAA file : files){
+    			file.cleanupExpirded();
+    		}
+    		sleep(10 * 60 * 1000); // sleep ten minutes
+    	} catch (InterruptedException e){
+    	} catch (Throwable e){
+    		Log.getLog().warn("DATABASE CLEANUP THREAD", e);
+    	}
+    	Log.getLog().info("database cleanup terminated");
+    }
+}

--- a/src/org/loklak/tools/storage/JsonFile.java
+++ b/src/org/loklak/tools/storage/JsonFile.java
@@ -1,6 +1,6 @@
 /**
  *  JsonFile
- *  Copyright 22.02.2015 by Robert Mader, @treba123
+ *  Copyright 03.06.2016 by Robert Mader, @treba123
  *
  *  This library is free software; you can redistribute it and/or
  *  modify it under the terms of the GNU Lesser General Public
@@ -25,6 +25,7 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Map;
+import java.util.Set;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -142,6 +143,19 @@ public class JsonFile extends JSONObject {
 	@Override
 	public synchronized Object remove(String key) {
 		super.remove(key);
+		commit();
+		return this;
+	}
+	
+	/**
+	 * Remove multiple keys but write only once to disk
+	 * @param keys
+	 * @return
+	 */
+	public synchronized Object removeSet(Set<String> keys) {
+		for(String key : keys){
+			super.remove(key);
+		}
 		commit();
 		return this;
 	}

--- a/src/org/loklak/tools/storage/JsonFileAAA.java
+++ b/src/org/loklak/tools/storage/JsonFileAAA.java
@@ -1,0 +1,61 @@
+/**
+ *  JsonFileAAA
+ *  Copyright 03.06.2016 by Robert Mader, @treba123
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *  
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *  
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program in the file lgpl21.txt
+ *  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.loklak.tools.storage;
+
+import java.io.File;
+import java.io.IOException;
+import java.time.Instant;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Set;
+
+import org.json.JSONObject;
+
+/**
+ * This extends JsonFile with a cleanup function, handy for thread-save cleanup of loklaks Authentication, Authorization and Accounting files
+ *
+ */
+public class JsonFileAAA extends JsonFile {
+
+	public JsonFileAAA(File file) throws IOException{
+		super(file);
+	}
+	
+	// remove all expired objects
+	public synchronized void cleanupExpirded(){
+		Iterator<String> keys = this.keys();
+		Set<String> expiredKeys = new HashSet<String>();
+		
+		// iterate over all keys
+		while(keys.hasNext()){
+			String key = keys.next();
+			JSONObject object = this.getJSONObject(key);
+			
+			// check if timestamp is still valid
+			if(object.has("expires_on") && object.getLong("expires_on") < Instant.now().getEpochSecond()){
+				// remove keys at the end to not confuse the iterator
+				expiredKeys.add(key);
+			}
+		}
+		
+		// if keys are expired, remove them in all
+		if(!expiredKeys.isEmpty()) super.removeSet(expiredKeys);
+	}
+}


### PR DESCRIPTION
This adds a cleanup thread for the AAA files, so we don't carry outdated information for ever, see https://github.com/loklak/loklak_server/issues/510

Right now it removes the following entries from the authentication file:
- anonymous logins (after 24h of inactivity)
- cookies (after a week of inactivity, which is the current expire time for long living cookies)
- it does not remove any entries without `expire_on` entry

The thread is modeled like the other threads to be in line and make it easy to understand, although technically, it probably should have been done as task with a tasksscheduler.

@Orbiter you removed the expire entries on the authorization file in https://github.com/loklak/loklak_server/commit/96fd4e7e186822756b96f0c2abc21c22ab96615f , but I'd suggest to clean it up aswell, as for every anonymous user, an authorization entry with an ip is made and carried around forever.
If you don't plan to change that anyway, we need to remove them after some time.
Same goes for accounting, if we start to make it saved permanently.