### PR TITLE
Fixes missing search box valuename for SEO Query

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -56,7 +56,7 @@
   "potentialAction": {
     "@type": "SearchAction",
     "target": "http://loklak.org/api/search.json?q={query}",
-    "query-input": "required"
+    "query-input": "required name=query"
   }
 }
     </script>


### PR DESCRIPTION
The value name was missing because of which the search box wasn't appearing. Tested with
https://search.google.com/structured-data/testing-tool/u/0/