### PR TITLE
Added basic email structure

### DIFF
--- a/conf/config.properties
+++ b/conf/config.properties
@@ -7,6 +7,22 @@
 # allow public signup
 users.public.signup=false
 
+# SMTP emailing switch (for password recovery and signup verification etc)
+smtp.mails.enabled=false
+
+# SMTP password recovery server host (change this as per need)
+smtp.host.name=smtp.gmail.com
+
+# sender email (change this as per need)
+smtp.host.senderid=server@loklak.org
+
+# depending on security of recovery host server, set authtype as none, starttls or tls
+# also make changes on server side: eg if server is gmail, turn POP3 and SMTP on
+smtp.host.encryption=tls
+
+# incase authtype = tls or ssl, set sender password and tls/ssl port
+smtp.host.senderpass=randomxyz
+smtp.host.port=465
 
 # the ports for the user front-end
 port.http=9000

--- a/html/apps/forgotpassword/js/passwordrecovery.js
+++ b/html/apps/forgotpassword/js/passwordrecovery.js
@@ -8,8 +8,11 @@ $(document).ready(function()
             alert("Please fill email");
         } else{
             var mail = encodeURIComponent($('#email').val());
-            alert("Email: " + mail + "\nSuccess, write post function");
-            //post function
+            var posting = $.post( "/api/email.json", { forgotemail: mail }, function(data) {
+                console.log(data.status);
+                console.log(data.reason);
+                alert(data.status + ", " + data.reason);
+            }, "json" );
         }
     });
 

--- a/src/org/loklak/LoklakEmailHandler.java
+++ b/src/org/loklak/LoklakEmailHandler.java
@@ -18,31 +18,105 @@
  */
 
 package org.loklak;
-
+import java.util.Date;
+import java.util.Properties;
 import java.util.regex.Pattern;
-import java.util.regex.PatternSyntaxException;
-
+import javax.mail.Message;
+import javax.mail.MessagingException;
+import javax.mail.PasswordAuthentication;
+import javax.mail.Session;
+import javax.mail.Transport;
+import javax.mail.internet.InternetAddress;
+import javax.mail.internet.MimeMessage;
 import org.eclipse.jetty.util.log.Log;
+import org.loklak.data.DAO;
+import org.loklak.server.Authorization;
+import org.loklak.server.ClientCredential;
 
 public class LoklakEmailHandler {
-	
-	private String addressTo;
-	private String addressFrom;
-	private String subject;
-	private String text;
-	private Pattern pattern;
-	private static final String EMAIL_PATTERN = "^[_A-Za-z0-9-\\+]+(\\.[_A-Za-z0-9-]+)*@" + "[A-Za-z0-9-]+(\\.[A-Za-z0-9]+)*(\\.[A-Za-z]{2,})$";
-	
-	public LoklakEmailHandler (String addressTo, String addressFrom, String subject, String text) throws PatternSyntaxException, IllegalStateException{
+
+	private static Pattern pattern;
+	private static final String EMAIL_PATTERN = "^[_A-Za-z0-9-\\+]+(\\.[_A-Za-z0-9-]+)*@"
+			+ "[A-Za-z0-9-]+(\\.[A-Za-z0-9]+)*(\\.[A-Za-z]{2,})$";
+
+	public static void sendEmail(String addressTo, String subject, String text, Authorization rights)
+			throws Exception {
+		
+		if (!rights.isAdmin() && !"true".equals(DAO.getConfig("smtp.mails.enabled", "false"))) {
+			throw new Exception("Mail sending disabled");
+		}
+		
 		pattern = Pattern.compile(EMAIL_PATTERN);
-		this.addressTo = addressTo;
-		this.addressFrom = addressFrom;
-		this.subject = subject;
-		this.text = text;
-		if(pattern.matcher(addressTo).matches() && pattern.matcher(addressFrom).matches()){
-			//send to server
+		
+		ClientCredential credential = new ClientCredential(ClientCredential.Type.passwd_login, addressTo);
+		String sender = DAO.getConfig("smtp.host.senderid", "server@loklak.org");
+		String pass = DAO.getConfig("smtp.host.senderpass", "randomxyz");
+		String hostname = DAO.getConfig("smtp.host.name", "smtp.gmail.com");
+		String type = DAO.getConfig("smtp.host.encryption", "tls");
+		String port = DAO.getConfig("smtp.host.port", "465");
+
+		if (!pattern.matcher(addressTo).matches()) {
+			throw new Exception("Invalid email ID");
+		}
+		if (!pattern.matcher(sender).matches()) {
+			throw new Exception("Invalid sender ID");
+		}
+
+		if (DAO.authentication.has(credential.toString())
+				&& ("none".equals(type) || "tls".equals(type) || "starttls".equals(type)))
+
+		{
+			java.util.Properties props;
+
+			if ("none".equals(type)) {
+				props = System.getProperties();
+			} else {
+				props = new Properties();
+				props.put("mail.smtp.auth", true);
+				props.put("mail.smtp.port", port);
+			}
+
+			props.put("mail.smtp.host", hostname);
+			props.put("mail.debug", true);
+
+			if ("starttls".equals(type)) {
+				props.put("mail.smtp.starttls.enable", true);
+			} else if ("tls".equals(type)) {
+				props.put("mail.smtp.socketFactory.port", port);
+				props.put("mail.smtp.socketFactory.class", "javax.net.ssl.SSLSocketFactory");
+			}
+
+			Session session;
+			if ("none".equals(type)) {
+				session = Session.getInstance(props, null);
+			} else {
+				session = Session.getInstance(props, new javax.mail.Authenticator() {
+					protected PasswordAuthentication getPasswordAuthentication() {
+						return new PasswordAuthentication(sender, pass);
+					}
+				});
+			}
+
+			try {
+
+				MimeMessage message = new MimeMessage(session);
+				message.addHeader("Content-type", "text/HTML; charset=UTF-8");
+				message.addHeader("format", "flowed");
+				message.addHeader("Content-Transfer-Encoding", "8bit");
+				message.setSentDate(new Date());
+				message.setFrom(new InternetAddress(sender));
+				message.setRecipients(Message.RecipientType.TO, InternetAddress.parse(addressTo, false));
+				message.setSubject(subject, "UTF-8");
+				message.setText(text, "UTF-8");
+				Transport.send(message);
+				Log.getLog().debug("status: ok", "reason: ok");
+
+			} catch (MessagingException mex) {
+				throw mex;
+			}
+
 		} else {
-			Log.getLog().info("Invalid email address");
+			throw new Exception("Receiver email does not exist or invalid encryption type");
 		}
 	}
 }

--- a/src/org/loklak/LoklakServer.java
+++ b/src/org/loklak/LoklakServer.java
@@ -74,6 +74,7 @@ import org.loklak.api.admin.ThreaddumpServlet;
 import org.loklak.api.cms.AppsService;
 import org.loklak.api.cms.AssetServlet;
 import org.loklak.api.cms.DumpDownloadServlet;
+import org.loklak.api.cms.PasswordRecoveryServlet;
 import org.loklak.api.cms.LoginServlet;
 import org.loklak.api.cms.ProxyServlet;
 import org.loklak.api.cms.SignUpServlet;
@@ -514,6 +515,7 @@ public class LoklakServer {
         servletHandler.addServlet(UserServlet.class, "/api/user.json");
         servletHandler.addServlet(SignUpServlet.class, "/api/signup.json");
         servletHandler.addServlet(LoginServlet.class, "/api/login.json");
+        servletHandler.addServlet(PasswordRecoveryServlet.class, "/api/recoverpassword.json");
         servletHandler.addServlet(CampaignServlet.class, "/api/campaign.json");
         servletHandler.addServlet(ImportProfileServlet.class, "/api/import.json");
         servletHandler.addServlet(SettingsServlet.class, "/api/settings.json");

--- a/src/org/loklak/api/cms/PasswordRecoveryServlet.java
+++ b/src/org/loklak/api/cms/PasswordRecoveryServlet.java
@@ -1,0 +1,79 @@
+/**
+ *  PasswordRecoveryServlet
+ *  Copyright 08.06.2016 by Shiven Mian, @shivenmian
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *  
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *  
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program in the file lgpl21.txt
+ *  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.loklak.api.cms;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import org.json.JSONObject;
+import org.loklak.LoklakEmailHandler;
+import org.loklak.server.APIException;
+import org.loklak.server.APIHandler;
+import org.loklak.server.APIServiceLevel;
+import org.loklak.server.AbstractAPIHandler;
+import org.loklak.server.Authorization;
+
+import org.loklak.server.Query;
+
+public class PasswordRecoveryServlet extends AbstractAPIHandler implements APIHandler {
+
+	private static final long serialVersionUID = 3515757746392011162L;
+
+	@Override
+	public String getAPIPath() {
+		return "/api/recoverpassword.json";
+	}
+
+	@Override
+	public APIServiceLevel getDefaultServiceLevel() {
+		return APIServiceLevel.PUBLIC;
+	}
+
+	@Override
+	public APIServiceLevel getCustomServiceLevel(Authorization auth) {
+		return APIServiceLevel.ADMIN;
+	}
+
+	@Override
+	public JSONObject serviceImpl(Query call, Authorization rights) throws APIException {
+		JSONObject result = new JSONObject();
+
+		String usermail;
+		try {
+			usermail = URLDecoder.decode(call.get("forgotemail", null), "UTF-8");
+		} catch (UnsupportedEncodingException e) {
+			result.put("status", "error");
+			result.put("reason", "malformed query");
+			return result;
+		}
+		
+		String subject = "Password Recovery";
+		String body = "Recover password using this link";
+		try {
+			LoklakEmailHandler.sendEmail(usermail, subject, body, rights);
+			result.put("status", "ok");
+			result.put("reason", "ok");
+		} catch(Exception e){
+			result.put("status", "error");
+			result.put("reason", e.toString());
+		}
+		return result;
+	}
+
+}


### PR DESCRIPTION
@treba123 @mariobehling @Orbiter I've added a basic email structure for the Password Recovery system in #467.

Since we do not have a server set up as of yet (we need one), I set the sender email as server@loklak.org and password as randomxyz (its a random name). We can change it later.

The user gets to set up his SMTP type, his hostname and port etc. in config file. Please see the options I have added there. He also has to make changes on the server side (for example if host is GMail then POP3 and SMTP should be turned on in their Settings, else mail will be found as suspicious). The email will then be sent.

I have kept the email body empty, because I just wanted to see if this structure is right. Once this is approved, I will simply make the Password Recovery HTML page (to set a new password) and put its link (I will append a hash to the link) in the body and the process will be complete.

I have not tested this because I don't have a server myself. But the build is successful though. Please review.