### PR TITLE
Use the APIServiceLevel to limit access to servlets

### DIFF
--- a/src/org/loklak/api/cms/LoginService.java
+++ b/src/org/loklak/api/cms/LoginService.java
@@ -39,7 +39,7 @@ public class LoginService extends AbstractAPIHandler implements APIHandler {
 
     @Override
     public APIServiceLevel getCustomServiceLevel(Authorization rights) {
-        return APIServiceLevel.ADMIN;
+    	return APIServiceLevel.PUBLIC;
     }
 
     public String getAPIPath() {

--- a/src/org/loklak/api/cms/SignUpService.java
+++ b/src/org/loklak/api/cms/SignUpService.java
@@ -91,7 +91,7 @@ public class SignUpService extends AbstractAPIHandler implements APIHandler {
     	}
     	
     	// is this a verification?
-    	if(post.get("validateEmail", false) && serviceLevel == APIServiceLevel.LIMITED){
+    	if(post.get("validateEmail", false) && serviceLevel.isGreaterThan(APIServiceLevel.PUBLIC)){
     		ClientCredential credential = new ClientCredential(ClientCredential.Type.passwd_login, rights.getIdentity().getName());
     		Authentication authentication = new Authentication(credential, DAO.authentication);
     		

--- a/src/org/loklak/server/APIServiceLevel.java
+++ b/src/org/loklak/server/APIServiceLevel.java
@@ -22,9 +22,20 @@ package org.loklak.server;
 
 public enum APIServiceLevel {
 
-    ADMIN,      // functions that modify the behavior of the server and the server's services
-    LIMITED,    // functions that are available in the public, but are limited in some way
-    PRODUCT,    // limited functions which can be unlimited if the user is granted that (by any way)
-    PUBLIC      // functions that are public and unlimited
+    ADMIN(3),      // functions that modify the behavior of the server and the server's services
+    LIMITED(2),    // functions that are available in the public, but are limited in some way
+    PRODUCT(1),    // limited functions which can be unlimited if the user is granted that (by any way)
+    PUBLIC(0);      // functions that are public and unlimited
     
+    private Integer level;
+
+	APIServiceLevel(int level) {
+        this.level = level;
+    }
+
+    public boolean equals(APIServiceLevel other) {return this.level == other.level;}
+    public boolean isSmallerThan(APIServiceLevel other) {return this.level < other.level;}
+    public boolean isSmallerOrEqualTo(APIServiceLevel other) {return this.level <= other.level;}
+    public boolean isGreaterThan(APIServiceLevel other) {return this.level > other.level;}
+    public boolean isGreaterOrEqualTo(APIServiceLevel other) {return this.level >= other.level;}
 }

--- a/src/org/loklak/server/AbstractAPIHandler.java
+++ b/src/org/loklak/server/AbstractAPIHandler.java
@@ -135,6 +135,11 @@ public abstract class AbstractAPIHandler extends HttpServlet implements APIHandl
         // user authorization: we use the identification of the user to get the assigned authorization
         Authorization authorization = new Authorization(identity, DAO.authorization);
 
+        if(getCustomServiceLevel(authorization).isSmallerThan(serviceLevel)){
+        	response.sendError(401, "Unauthorized");
+			return;
+        }
+        
         // user accounting: we maintain static and persistent user data; we again search the accounts using the usder identity string
         //JSONObject accounting_persistent_obj = DAO.accounting_persistent.has(user_id) ? DAO.accounting_persistent.getJSONObject(anon_id) : DAO.accounting_persistent.put(user_id, new JSONObject()).getJSONObject(user_id);
         Accounting accounting_temporary = DAO.accounting_temporary.get(identity.toString());


### PR DESCRIPTION
This makes APIServiceLevel comparable and makes AbstractAPIHandler return a 401 if the service level a user has does not match the default service level.

I created that as part to understand how APIServiceLevel is meant to work, for discussion.

The idea behind it is that, for propper API, if a user does not have the rights to do something, we should respond with a propper http status.
Currently, this is only possible within AbstactAPIHandler, not in a servlet extending it (actually we can return null, but then a 400 is responded, which is not always the right answer).
Therefor it would be desireble if AbstactAPIHandler checks if the user has the basic rights to access a servlet.