### PR TITLE
Added reset servlet + password change functionality

### DIFF
--- a/conf/templates/reset-mail.txt
+++ b/conf/templates/reset-mail.txt
@@ -1,0 +1,7 @@
+You just requested for a password reset for your loklak account.
+
+To do so, click on the following link:
+
+%RESET-LINK%
+
+If you didn't ask for a password reset, please ignore this email.

--- a/conf/templates/verification-mail.txt
+++ b/conf/templates/verification-mail.txt
@@ -1,6 +1,6 @@
 You just signed up for Loklak!
 
-To finish the process, you have to verificate you email address by clicking on the following link:
+To finish the process, you have to verify you email address by clicking on the following link:
 
 %VERIFICATION-LINK%
 

--- a/src/org/loklak/LoklakServer.java
+++ b/src/org/loklak/LoklakServer.java
@@ -75,6 +75,7 @@ import org.loklak.api.cms.AppsService;
 import org.loklak.api.cms.AssetServlet;
 import org.loklak.api.cms.DumpDownloadServlet;
 import org.loklak.api.cms.PasswordRecoveryService;
+import org.loklak.api.cms.PasswordResetService;
 import org.loklak.api.cms.LoginService;
 import org.loklak.api.cms.ProxyServlet;
 import org.loklak.api.cms.SignUpService;
@@ -511,7 +512,8 @@ public class LoklakServer {
                 LoginService.class,
                 PasswordRecoveryService.class,
                 TopMenuService.class,
-        		ClientHandshake.class};
+        		ClientHandshake.class,
+        		PasswordResetService.class};
         for (Class<? extends Servlet> service: services)
             try {
                 servletHandler.addServlet(service, ((APIHandler) (service.newInstance())).getAPIPath());

--- a/src/org/loklak/api/cms/PasswordRecoveryService.java
+++ b/src/org/loklak/api/cms/PasswordRecoveryService.java
@@ -19,21 +19,28 @@
 
 package org.loklak.api.cms;
 
+import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
+import java.nio.file.Paths;
 import org.json.JSONObject;
 import org.loklak.LoklakEmailHandler;
+import org.loklak.data.DAO;
 import org.loklak.server.APIException;
 import org.loklak.server.APIHandler;
 import org.loklak.server.APIServiceLevel;
 import org.loklak.server.AbstractAPIHandler;
+import org.loklak.server.Authentication;
 import org.loklak.server.Authorization;
-
+import org.loklak.server.ClientCredential;
+import org.loklak.server.ClientIdentity;
 import org.loklak.server.Query;
+import org.loklak.tools.IO;
 
 public class PasswordRecoveryService extends AbstractAPIHandler implements APIHandler {
 
 	private static final long serialVersionUID = 3515757746392011162L;
+	private static String resetLinkPlaceholder = "%RESET-LINK%";
 
 	@Override
 	public String getAPIPath() {
@@ -54,6 +61,28 @@ public class PasswordRecoveryService extends AbstractAPIHandler implements APIHa
 	public JSONObject serviceImpl(Query call, Authorization rights) throws APIException {
 		JSONObject result = new JSONObject();
 
+		// check if token exists
+
+		if (call.get("getParameters", false) && call.get("token", null) != null) {
+			ClientCredential credentialcheck = new ClientCredential(ClientCredential.Type.resetpass_token,
+					call.get("token", null));
+			if (DAO.passwordreset.has(credentialcheck.toString())) {
+				Authentication authentication = new Authentication(credentialcheck, DAO.passwordreset);
+				if (authentication.checkExpireTime()) {
+					result.put("status", "success");
+					result.put("reason", authentication.getIdentity().getName());
+					return result;
+				}
+				result.put("status", "error");
+				result.put("reason", "Expired token");
+				authentication.delete();
+				return result;
+			}
+			result.put("status", "error");
+			result.put("reason", "Invalid token");
+			return result;
+		}
+
 		String usermail;
 		try {
 			usermail = URLDecoder.decode(call.get("forgotemail", null), "UTF-8");
@@ -62,17 +91,49 @@ public class PasswordRecoveryService extends AbstractAPIHandler implements APIHa
 			result.put("reason", "malformed query");
 			return result;
 		}
-		
+
+		ClientCredential credential = new ClientCredential(ClientCredential.Type.passwd_login, usermail);
+		ClientIdentity identity = new ClientIdentity(ClientIdentity.Type.email, credential.getName());
+
+		if (!DAO.authentication.has(credential.toString())) {
+			result.put("status", "error");
+			result.put("reason", "email does not exist");
+			return result;
+		}
+
+		String token = createRandomString(30);
+		ClientCredential tokenkey = new ClientCredential(ClientCredential.Type.resetpass_token, token);
+		Authentication resetauth = new Authentication(tokenkey, DAO.passwordreset);
+		resetauth.setIdentity(identity);
+		resetauth.setExpireTime(7 * 24 * 60 * 60);
+		resetauth.put("one_time", true);
+
 		String subject = "Password Recovery";
-		String body = "Recover password using this link";
 		try {
-			LoklakEmailHandler.sendEmail(usermail, subject, body);
+			LoklakEmailHandler.sendEmail(usermail, subject, getVerificationMailContent(token));
 			result.put("status", "ok");
 			result.put("reason", "ok");
-		} catch(Exception e){
+		} catch (Exception e) {
 			result.put("status", "error");
 			result.put("reason", e.toString());
 		}
+		return result;
+	}
+
+	private String getVerificationMailContent(String token) {
+
+		String verificationLink = DAO.getConfig("host.name", "http://localhost:9000") + "/apps/resetpass/index.html?token="
+				+ token;
+		String result;
+		try {
+			result = IO.readFileCached(Paths.get(DAO.conf_dir + "/templates/reset-mail.txt"));
+		} catch (IOException e) {
+			result = "";
+		}
+
+		result = result.contains(resetLinkPlaceholder) ? result.replace(resetLinkPlaceholder, verificationLink)
+				: verificationLink;
+
 		return result;
 	}
 

--- a/src/org/loklak/api/cms/PasswordResetService.java
+++ b/src/org/loklak/api/cms/PasswordResetService.java
@@ -1,0 +1,91 @@
+/**
+ *  PasswordResetService
+ *  Copyright 17.06.2016 by Shiven Mian, @shivenmian
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *  
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *  
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program in the file lgpl21.txt
+ *  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.loklak.api.cms;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import org.json.JSONObject;
+import org.loklak.data.DAO;
+import org.loklak.server.APIException;
+import org.loklak.server.APIHandler;
+import org.loklak.server.APIServiceLevel;
+import org.loklak.server.AbstractAPIHandler;
+import org.loklak.server.Authentication;
+import org.loklak.server.Authorization;
+import org.loklak.server.ClientCredential;
+import org.loklak.server.Query;
+
+public class PasswordResetService extends AbstractAPIHandler implements APIHandler {
+
+	private static final long serialVersionUID = -8893457607971788891L;
+
+	@Override
+	public String getAPIPath() {
+		return "/api/resetpassword.json";
+	}
+
+	@Override
+	public APIServiceLevel getDefaultServiceLevel() {
+
+		return APIServiceLevel.PUBLIC;
+	}
+
+	@Override
+	public APIServiceLevel getCustomServiceLevel(Authorization auth) {
+
+		return APIServiceLevel.ADMIN;
+	}
+
+	@Override
+	public JSONObject serviceImpl(Query call, Authorization rights) throws APIException {
+		JSONObject result = new JSONObject();
+
+		String newpass;
+		try {
+			newpass = URLDecoder.decode(call.get("newpass", null), "UTF-8");
+		} catch (UnsupportedEncodingException e) {
+			result.put("status", "error");
+			result.put("reason", "malformed query");
+			return result;
+		}
+		ClientCredential credential = new ClientCredential(ClientCredential.Type.resetpass_token,
+				call.get("token", null));
+		Authentication authentication = new Authentication(credential, DAO.passwordreset);
+		ClientCredential emailcred = new ClientCredential(ClientCredential.Type.passwd_login,
+				authentication.getIdentity().getName());
+		
+		if(DAO.authentication.has(emailcred.toString())){
+			Authentication emailauth = new Authentication(emailcred, DAO.authentication);
+			String salt = createRandomString(20);
+			emailauth.remove("salt");
+			emailauth.remove("passwordHash");
+			emailauth.put("salt", salt);
+			emailauth.put("passwordHash", getHash(newpass, salt));
+		}
+
+		if (authentication.has("one_time") && authentication.getBoolean("one_time")) {
+			authentication.delete();
+		}
+		result.put("status", "ok");
+		result.put("reason", "password changed");
+		return result;
+	}
+
+}

--- a/src/org/loklak/data/DAO.java
+++ b/src/org/loklak/data/DAO.java
@@ -146,6 +146,7 @@ public class DAO {
     public static JsonTray authentication;
     public static JsonTray authorization;
     public static JsonTray accounting;
+    public static JsonTray passwordreset;
     public static Map<String, Accounting> accounting_temporary = new HashMap<>();
     
     public static enum IndexName {
@@ -229,7 +230,9 @@ public class DAO {
         Path authorization_path = settings_dir.resolve("authorization.json");
         authorization = new JsonTray(authorization_path.toFile(), 10000);
         OS.protectPath(authorization_path);
-        
+        Path passwordreset_path = settings_dir.resolve("passwordreset.json");
+        passwordreset = new JsonTray(passwordreset_path.toFile(), 10000);
+        OS.protectPath(passwordreset_path);
         // open index
         Path index_dir = dataPath.resolve("index");
         if (index_dir.toFile().exists()) OS.protectPath(index_dir); // no other permissions to this path

--- a/src/org/loklak/server/ClientCredential.java
+++ b/src/org/loklak/server/ClientCredential.java
@@ -28,6 +28,7 @@ public class ClientCredential extends Client {
     	passwd_login(true),
         cookie(false),
         access_token(false),
+        resetpass_token(false),
         host(false);
         private final boolean persistent;
         Type(final boolean persistent) {


### PR DESCRIPTION
This is a fix for #467 Part 3. I'm unsure if this will work because I haven't tested it so I do need feedback. 

This code first sends email with a reset link once password change is requested (reset link has a token). This reset link is sent as a param to the resetpass app (yet to code), and through the token, we can display to the user which email ID's password is being changed. I have decided to keep a file named ```passwordreset.json``` which stores tokens as keys, and the value of every token is a JSONObject which again consists of id, one_time and expiry time. Mapping keys to ID (rather than the other way round) was more convenient for me to reduce code complexity.

Once password is changed, I will check on the client-side (i.e on app) itself whether password is right etc, and then token and new password is posted to ```resetpassword.json```, and through token we figure out the email ID in ```DAO.authentication```, and set the new password.

I will code up the resetpass webpage (as described above) ASAP, it's not a big deal now that I've coded this.

Please review and give me feedback in this if there is anything wrong, I will fix it. @Orbiter @treba123 @mariobehling. 