### PR TITLE
make travis only build once on PRs from branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,7 @@ script:
   - bin/start.sh
 
 install: true
+
+branches:
+  only:
+    - "master"


### PR DESCRIPTION
At the moment, the travis build builds the project two times when doing a PR to master from a branch of the loklak repo. This should fix that