### PR TITLE
Added some more categories to susi_abstraction_en JSON file

### DIFF
--- a/conf/susi/susi_abstraction_en.json
+++ b/conf/susi/susi_abstraction_en.json
@@ -114,6 +114,11 @@
 		"tell":["disclose", "reveal", "show", "expose", "uncover", "relate", "narrate", "inform", "advise", "explain", "divulge", "declare", "command", "order", "bid", "recount", "repeat"],
 		"think":["judge", "deem", "assume", "believe", "consider", "contemplate", "reflect", "mediate"],
 		"trouble":["distress", "anguish", "anxiety", "worry", "wretchedness", "pain", "danger", "peril", "disaster", "grief", "misfortune", "difficulty", "concern", "pains", "inconvenience", "exertion", "effort"],
+		"true":["accurate", "right", "proper", "precise", "exact", "valid", "genuine", "real", "actual", "trusty", "steady", "loyal", "dependable", "sincere", "staunch"],
+		"take":["hold", "catch", "seize", "grasp", "win", "capture", "acquire", "pick", "choose", "select", "prefer", "remove", "steal", "lift", "rob", "engage", "bewitch", "purchase", "buy", "retract", "recall", "assume", "occupy", "consume"],
+		"tell":["disclose", "reveal", "show", "expose", "uncover", "relate", "narrate", "inform", "advise", "explain", "divulge", "declare", "command", "order", "bid", "recount", "repeat"],
+		"think":["judge", "deem", "assume", "believe", "consider", "contemplate", "reflect", "mediate"],
+		"trouble":["distress", "anguish", "anxiety", "worry", "wretchedness", "pain", "danger", "peril", "disaster", "grief", "misfortune", "difficulty", "concern", "pains", "inconvenience", "exertion", "effort"],
 		"true":["accurate", "right", "proper", "precise", "exact", "valid", "genuine", "real", "actual", "trusty", "steady", "loyal", "dependable", "sincere", "staunch"]
 	},
 	"multi":{

--- a/conf/susi/susi_abstraction_en.json
+++ b/conf/susi/susi_abstraction_en.json
@@ -119,7 +119,11 @@
 		"tell":["disclose", "reveal", "show", "expose", "uncover", "relate", "narrate", "inform", "advise", "explain", "divulge", "declare", "command", "order", "bid", "recount", "repeat"],
 		"think":["judge", "deem", "assume", "believe", "consider", "contemplate", "reflect", "mediate"],
 		"trouble":["distress", "anguish", "anxiety", "worry", "wretchedness", "pain", "danger", "peril", "disaster", "grief", "misfortune", "difficulty", "concern", "pains", "inconvenience", "exertion", "effort"],
-		"true":["accurate", "right", "proper", "precise", "exact", "valid", "genuine", "real", "actual", "trusty", "steady", "loyal", "dependable", "sincere", "staunch"]
+		"true":["accurate", "right", "proper", "precise", "exact", "valid", "genuine", "real", "actual", "trusty", "steady", "loyal", "dependable", "sincere", "staunch"],
+		"ugly":["hideous", "frightful", "frightening", "shocking", "horrible", "unpleasant", "monstrous", "terrifying", "gross", "grisly", "ghastly", "horrid", "unsightly", "plain", "homely", "evil", "repulsive", "repugnant", "gruesome"],
+		"unhappy":["miserable", "uncomfortable", "wretched", "heart-broken", "unfortunate", "poor", "downhearted", "sorrowful", "depressed", "dejected", "melancholy", "glum", "gloomy", "dismal", "discouraged", "sad"],
+		"use":["employ", "utilize", "exhaust", "spend", "expend", "consume", "exercise"],
+		"wrong":["incorrect", "inaccurate", "mistaken", "erroneous", "improper", "unsuitable"]
 	},
 	"multi":{
 		"intro":["There might be several right answers..."],

--- a/conf/susi/susi_abstraction_en.json
+++ b/conf/susi/susi_abstraction_en.json
@@ -99,7 +99,17 @@
 		"popular":["well-liked", "approved", "accepted", "favorite", "celebrated", "common", "current"],
 		"predicament":["quandary", "dilemma", "pickle", "problem", "plight", "spot", "scrape", "jam"],
 		"put":["place", "set", "attach", "establish", "assign", "keep", "save", "set aside", "effect", "achieve", "do", "build"],
-		"sad": ["unhappy", "depressed", "sick"]
+		"quiet":["silent", "still", "soundless", "mute", "tranquil", "peaceful", "calm", "restful"],
+		"right":["correct", "accurate", "factual", "true", "good", "just", "honest", "upright", "lawful", "moral", "proper", "suitable", "apt", "legal", "fair"],
+		"run":["race", "speed", "hurry", "hasten", "sprint", "dash", "rush", "escape", "elope", "flee"],
+		"say":["inform", "notify", "advise", "relate", "recount", "narrate", "explain", "reveal", "disclose", "divulge", "declare", "command", "order", "bid", "enlighten", "instruct", "insist", "teach", "train", "direct", "issue", "remark", "converse", "speak", "affirm", "suppose", "utter", "negate", "express", "verbalize", "voice", "articulate", "pronounce", "deliver", "convey", "impart", "assert", "state", "allege", "mutter", "mumble", "whisper", "sigh", "exclaim", "yell", "sing", "yelp", "snarl", "hiss", "grunt", "snort", "roar", "bellow", "thunder", "boom", "scream", "shriek", "screech", "squawk", "whine", "philosophize", "stammer", "stutter", "lisp", "drawl", "jabber", "protest", "announce", "swear", "vow", "content", "assure", "deny", "dispute"],
+		"sad": ["unhappy", "depressed", "sick"],
+		"scared":["afraid", "frightened", "alarmed", "terrified", "panicked", "fearful", "unnerved", "insecure", "timid", "shy", "skittish", "jumpy", "disquieted", "worried", "vexed", "troubled", "disturbed", "horrified", "terrorized", "shocked", "petrified", "haunted", "timorous", "shrinking", "tremulous", "stupefied", "paralyzed", "stunned", "apprehensive"],
+		"show":["display", "exhibit", "present", "note", "indicate", "explain", "reveal", "prove", "demonstrate", "expose"],
+		"slow":["unhurried", "gradual", "leisurely", "late", "behind", "tedious", "slack"],
+		"stop":["cease", "halt", "stay", "pause", "discontinue", "conclude", "end", "finish", "quit"],
+		"story":["tale", "myth", "legend", "fable", "yarn", "account", "narrative", "chronicle", "epic", "sage", "anecdote", "record", "memoir"],
+		"strange":["odd", "peculiar", "unusual", "unfamiliar", "uncommon", "queer", "weird", "outlandish", "curious", "unique", "exclusive", "irregular"]
 	},
 	"multi":{
 		"intro":["There might be several right answers..."],

--- a/conf/susi/susi_abstraction_en.json
+++ b/conf/susi/susi_abstraction_en.json
@@ -109,7 +109,12 @@
 		"slow":["unhurried", "gradual", "leisurely", "late", "behind", "tedious", "slack"],
 		"stop":["cease", "halt", "stay", "pause", "discontinue", "conclude", "end", "finish", "quit"],
 		"story":["tale", "myth", "legend", "fable", "yarn", "account", "narrative", "chronicle", "epic", "sage", "anecdote", "record", "memoir"],
-		"strange":["odd", "peculiar", "unusual", "unfamiliar", "uncommon", "queer", "weird", "outlandish", "curious", "unique", "exclusive", "irregular"]
+		"strange":["odd", "peculiar", "unusual", "unfamiliar", "uncommon", "queer", "weird", "outlandish", "curious", "unique", "exclusive", "irregular"],
+		"take":["hold", "catch", "seize", "grasp", "win", "capture", "acquire", "pick", "choose", "select", "prefer", "remove", "steal", "lift", "rob", "engage", "bewitch", "purchase", "buy", "retract", "recall", "assume", "occupy", "consume"],
+		"tell":["disclose", "reveal", "show", "expose", "uncover", "relate", "narrate", "inform", "advise", "explain", "divulge", "declare", "command", "order", "bid", "recount", "repeat"],
+		"think":["judge", "deem", "assume", "believe", "consider", "contemplate", "reflect", "mediate"],
+		"trouble":["distress", "anguish", "anxiety", "worry", "wretchedness", "pain", "danger", "peril", "disaster", "grief", "misfortune", "difficulty", "concern", "pains", "inconvenience", "exertion", "effort"],
+		"true":["accurate", "right", "proper", "precise", "exact", "valid", "genuine", "real", "actual", "trusty", "steady", "loyal", "dependable", "sincere", "staunch"]
 	},
 	"multi":{
 		"intro":["There might be several right answers..."],


### PR DESCRIPTION
Categories , fillers and synonyms are three terms which are being used to classify an expression from the Susi rule. Susi reads a particular expression and categorizes based on the key terms and understands the meaning of it. This PR had some general words(which are categories) each with a set of other related words (related to the meaning of the root word). This is the initial category list added to Susi. 