### PR TITLE
Fixes #762: Fixes the filtering issue on the apps page

### DIFF
--- a/html/apps/NMEA/app.json
+++ b/html/apps/NMEA/app.json
@@ -5,7 +5,7 @@
   "name":"NMEA",
   "headline":"GPS Device Tracking",
   "alternativeHeadline":"Tracking GPS NMEA Data using Loklak and OpenStreetMaps",
-  "applicationCategory":"IOT",
+  "applicationCategory":"Internet Of Things",
   "applicationSubCategory":"GPS",
   "operatingSystem":"http://loklak.org",
   "author":{


### PR DESCRIPTION
#762 
This fixes the filtering issue with the IOT category. This occurs when the name for the application category do not follow the camel casing where the first letter is in uppercase. The parser reads accordingly and displays the apps under the given name.  