### PR TITLE
Fix erroneous results in location-wise-time

### DIFF
--- a/src/org/loklak/api/search/LocationWiseTimeService.java
+++ b/src/org/loklak/api/search/LocationWiseTimeService.java
@@ -85,8 +85,7 @@ public class LocationWiseTimeService extends AbstractAPIHandler implements APIHa
 				JSONObject obj = new JSONObject();
 				String l = e.getElementsByTag("a").text();
 				obj.put("location", l);
-				e = e.siblingElements().get(0);
-				String t = e.text();
+				String t = e.nextElementSibling().text();
 				obj.put("time", t);
 				arr.put(obj);
 			}


### PR DESCRIPTION
... wrt #759 

Sample Link: [http://localhost:9000/api/console.json?q=SELECT * FROM locationwisetime WHERE query='berlin';](http://localhost:9000/api/console.json?q=SELECT%20*%20FROM%20locationwisetime%20WHERE%20query=%27berlin%27;)