### PR TITLE
Fixes #750: Implement Amazon API

### DIFF
--- a/conf/config.properties
+++ b/conf/config.properties
@@ -65,6 +65,11 @@ https.keysource=keystore
 keystore.name=keystore.jks
 keystore.password=123456
 
+#amazon API settings
+aws_secret_key=randomxyz
+aws_associate_tag=randomxyz
+aws_access_key_id=randomxyz
+
 # ssl-key in common pem format
 https.key=/etc/ssl/private/loklak_key.pem
 # if you need intermediate certificates, just combine all certs into one file, just like for nginx

--- a/src/org/loklak/LoklakServer.java
+++ b/src/org/loklak/LoklakServer.java
@@ -78,6 +78,7 @@ import org.loklak.api.admin.CrawlerServlet;
 import org.loklak.api.admin.SettingsServlet;
 import org.loklak.api.admin.StatusService;
 import org.loklak.api.admin.ThreaddumpServlet;
+import org.loklak.api.amazon.AmazonProductService;
 import org.loklak.api.cms.*;
 import org.loklak.api.geo.GeocodeServlet;
 import org.loklak.api.iot.FossasiaPushServlet;
@@ -106,6 +107,7 @@ import org.loklak.api.search.GithubProfileScraper;
 import org.loklak.api.search.InstagramProfileScraper;
 import org.loklak.api.search.LocationWiseTimeService;
 import org.loklak.api.search.WeiboUserInfo;
+import org.loklak.api.search.WikiGeoData;
 import org.loklak.api.search.MeetupsCrawlerService;
 import org.loklak.api.search.RSSReaderService;
 import org.loklak.api.tools.CSVServlet;
@@ -507,6 +509,7 @@ public class LoklakServer {
                 TopMenuService.class,
                 UserManagementService.class,
                 TwitterAnalysisService.class,
+                AmazonProductService.class,
                 
                 // geo
                 
@@ -526,7 +529,7 @@ public class LoklakServer {
                 InstagramProfileScraper.class,
                 LocationWiseTimeService.class,
                 TimeAndDateService.class,
-                //WikiGeoData.class
+                WikiGeoData.class
                 
                 // tools
                 

--- a/src/org/loklak/api/amazon/AmazonProductService.java
+++ b/src/org/loklak/api/amazon/AmazonProductService.java
@@ -1,0 +1,162 @@
+/**
+ *  AmazonProductService
+ *  Copyright 05.08.2016 by Shiven Mian, @shivenmian
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *  
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *  
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program in the file lgpl21.txt
+ *  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.loklak.api.amazon;
+
+import java.io.StringWriter;
+
+import javax.servlet.http.HttpServletResponse;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+
+import org.json.JSONObject;
+import org.json.XML;
+import org.loklak.data.DAO;
+import org.loklak.server.APIException;
+import org.loklak.server.APIHandler;
+import org.loklak.server.AbstractAPIHandler;
+import org.loklak.server.Authorization;
+import org.loklak.server.BaseUserRole;
+import org.loklak.server.Query;
+import org.loklak.tools.storage.JSONObjectWithDefault;
+import org.w3c.dom.Document;
+
+public class AmazonProductService extends AbstractAPIHandler implements APIHandler {
+
+	private static final long serialVersionUID = 2279773523424505716L;
+
+	// set your key configuration in config.properties under the Amazon API
+	// Settings field
+	private static final String AWS_ACCESS_KEY_ID = DAO.getConfig("aws_access_key_id", "randomxyz");
+	private static final String AWS_SECRET_KEY = DAO.getConfig("aws_secret_key", "randomxyz");
+	private static final String ASSOCIATE_TAG = DAO.getConfig("aws_associate_tag", "randomxyz");
+
+	// using the USA locale
+	private static final String ENDPOINT = "webservices.amazon.com";
+
+	@Override
+	public String getAPIPath() {
+		return "/cms/amazonservice.json";
+	}
+
+	@Override
+	public BaseUserRole getMinimalBaseUserRole() {
+		return BaseUserRole.ANONYMOUS;
+	}
+
+	@Override
+	public JSONObject getDefaultPermissions(BaseUserRole baseUserRole) {
+		return null;
+	}
+
+	public static JSONObject fetchResults(String requestUrl, String operation) {
+		JSONObject itemlookup = new JSONObject(true);
+		try {
+			DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+			DocumentBuilder db = dbf.newDocumentBuilder();
+			Document doc = db.parse(requestUrl);
+			DOMSource domSource = new DOMSource(doc);
+			StringWriter writer = new StringWriter();
+			StreamResult result = new StreamResult(writer);
+			TransformerFactory tf = TransformerFactory.newInstance();
+			Transformer transformer = tf.newTransformer();
+			transformer.transform(domSource, result);
+			JSONObject xmlresult = new JSONObject(true);
+			xmlresult = XML.toJSONObject(writer.toString());
+			JSONObject items = xmlresult.getJSONObject(operation).getJSONObject("Items");
+			if (items.getJSONObject("Request").has("Errors")) {
+				itemlookup.put("status", "error");
+				itemlookup.put("reason",
+						items.getJSONObject("Request").getJSONObject("Errors").getJSONObject("Error").get("Message"));
+				return itemlookup;
+			}
+			itemlookup.put("number_of_items",
+					(operation.equals("ItemLookupResponse") ? "1" : (items.getJSONArray("Item").length())));
+			itemlookup.put("list_of_items", items);
+		} catch (Exception e) {
+			itemlookup.put("status", "error");
+			itemlookup.put("reason", e);
+			return itemlookup;
+		}
+		return itemlookup;
+	}
+
+	@Override
+	public JSONObject serviceImpl(Query call, HttpServletResponse response, Authorization rights,
+			JSONObjectWithDefault permissions) throws APIException {
+		String ITEM_ID = call.get("id", "");
+		String PRODUCT_NAME = call.get("q", "");
+		String responsegroup = (call.get("response_group", "") != "" ? call.get("response_group", "") : "Large");
+		if (!("".equals(ITEM_ID)) && ITEM_ID.length() != 0) {
+			return itemLookup(ITEM_ID, responsegroup);
+		} else if (!("".equals(PRODUCT_NAME)) && PRODUCT_NAME.length() != 0) {
+			return itemSearch(PRODUCT_NAME, responsegroup);
+		} else {
+			return new JSONObject().put("error", "no parameters given");
+		}
+	}
+
+	public JSONObject itemSearch(String query, String responsegroup) {
+		JSONObject result = new JSONObject(true);
+		SignedRequestsHelper helper;
+		if (query.length() == 0 || "".equals(query)) {
+			result.put("error", "Please specify a query to search");
+			return result;
+		}
+		try {
+			helper = SignedRequestsHelper.getInstance(ENDPOINT, AWS_ACCESS_KEY_ID, AWS_SECRET_KEY, ASSOCIATE_TAG);
+		} catch (Exception e) {
+			result.put("error", e.toString());
+			return result;
+		}
+		String requestUrl = null;
+		String queryString = "Service=AWSECommerceService&ResponseGroup=" + responsegroup
+				+ "&Operation=ItemSearch&Keywords=" + query + "&SearchIndex=All";
+		requestUrl = helper.sign(queryString);
+		result = fetchResults(requestUrl, "ItemSearchResponse");
+		return result;
+	}
+
+	public JSONObject itemLookup(String asin, String responsegroup) {
+		SignedRequestsHelper helper;
+		JSONObject result = new JSONObject(true);
+		if (asin.length() == 0 || "".equals(asin)) {
+			result.put("error", "Please specify an Item ID");
+			return result;
+		}
+
+		try {
+			helper = SignedRequestsHelper.getInstance(ENDPOINT, AWS_ACCESS_KEY_ID, AWS_SECRET_KEY, ASSOCIATE_TAG);
+		} catch (Exception e) {
+			result.put("error", e.toString());
+			return result;
+		}
+		String requestUrl = null;
+		String queryString = "Service=AWSECommerceService&ResponseGroup=" + responsegroup
+				+ "&Operation=ItemLookup&ItemId=" + asin;
+		requestUrl = helper.sign(queryString);
+		result = fetchResults(requestUrl, "ItemLookupResponse");
+		return result;
+	}
+
+}

--- a/src/org/loklak/api/amazon/SignedRequestsHelper.java
+++ b/src/org/loklak/api/amazon/SignedRequestsHelper.java
@@ -1,0 +1,298 @@
+/**********************************************************************************************
+ * Copyright 2009 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file 
+ * except in compliance with the License. A copy of the License is located at
+ *
+ *       http://aws.amazon.com/apache2.0/
+ *
+ * or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under the License. 
+ *
+ * ********************************************************************************************
+ *
+ *  Amazon Product Advertising API
+ *  Signed Requests Sample Code
+ *
+ *  API Version: 2009-03-31
+ *
+ */
+
+package org.loklak.api.amazon;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import java.net.URLEncoder;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Base64;
+import java.util.Calendar;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.TimeZone;
+import java.util.TreeMap;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+
+/**
+ * This class contains all the logic for signing requests to the Amazon Product
+ * Advertising API.
+ */
+public class SignedRequestsHelper {
+	/**
+	 * All strings are handled as UTF-8
+	 */
+	private static final String UTF8_CHARSET = "UTF-8";
+
+	/**
+	 * The HMAC algorithm required by Amazon
+	 */
+	private static final String HMAC_SHA256_ALGORITHM = "HmacSHA256";
+
+	/**
+	 * This is the URI for the service, don't change unless you really know what
+	 * you're doing.
+	 */
+	private static final String REQUEST_URI = "/onca/xml";
+
+	/**
+	 * The sample uses HTTP GET to fetch the response. If you changed the sample
+	 * to use HTTP POST instead, change the value below to POST.
+	 */
+	private static final String REQUEST_METHOD = "GET";
+
+	private String endpoint = null;
+	private String awsAccessKeyId = null;
+	private String awsSecretKey = null;
+	private String associatetag = null;
+	private SecretKeySpec secretKeySpec = null;
+	private Mac mac = null;
+
+	/**
+	 * You must provide the three values below to initialize the helper.
+	 * 
+	 * @param endpoint
+	 *            Destination for the requests.
+	 * @param awsAccessKeyId
+	 *            Your AWS Access Key ID
+	 * @param awsSecretKey
+	 *            Your AWS Secret Key
+	 */
+	public static SignedRequestsHelper getInstance(String endpoint, String awsAccessKeyId, String awsSecretKey,
+			String associatetag) throws IllegalArgumentException, UnsupportedEncodingException,
+			NoSuchAlgorithmException, InvalidKeyException {
+		if (null == endpoint || endpoint.length() == 0) {
+			throw new IllegalArgumentException("endpoint is null or empty");
+		}
+		if (null == awsAccessKeyId || awsAccessKeyId.length() == 0) {
+			throw new IllegalArgumentException("awsAccessKeyId is null or empty");
+		}
+		if (null == awsSecretKey || awsSecretKey.length() == 0) {
+			throw new IllegalArgumentException("awsSecretKey is null or empty");
+		}
+
+		if (null == associatetag || associatetag.length() == 0) {
+			throw new IllegalArgumentException("associatetag is null or empty");
+		}
+
+		SignedRequestsHelper instance = new SignedRequestsHelper();
+		instance.endpoint = endpoint.toLowerCase();
+		instance.awsAccessKeyId = awsAccessKeyId;
+		instance.awsSecretKey = awsSecretKey;
+		instance.associatetag = associatetag;
+
+		byte[] secretyKeyBytes = instance.awsSecretKey.getBytes(UTF8_CHARSET);
+		instance.secretKeySpec = new SecretKeySpec(secretyKeyBytes, HMAC_SHA256_ALGORITHM);
+		instance.mac = Mac.getInstance(HMAC_SHA256_ALGORITHM);
+		instance.mac.init(instance.secretKeySpec);
+
+		return instance;
+	}
+
+	/**
+	 * The construct is private since we'd rather use getInstance()
+	 */
+	private SignedRequestsHelper() {
+	}
+
+	/**
+	 * This method signs requests in hashmap form. It returns a URL that should
+	 * be used to fetch the response. The URL returned should not be modified in
+	 * any way, doing so will invalidate the signature and Amazon will reject
+	 * the request.
+	 */
+	public String sign(Map<String, String> params) {
+		// Let's add the AWSAccessKeyId, AssociateTag and Timestamp parameters
+		// to the request.
+		params.put("AWSAccessKeyId", this.awsAccessKeyId);
+		params.put("AssociateTag", this.associatetag);
+		params.put("Timestamp", this.timestamp());
+
+		// The parameters need to be processed in lexicographical order, so
+		// we'll
+		// use a TreeMap implementation for that.
+		SortedMap<String, String> sortedParamMap = new TreeMap<String, String>(params);
+
+		// get the canonical form the query string
+		String canonicalQS = this.canonicalize(sortedParamMap);
+
+		// create the string upon which the signature is calculated
+		String toSign = REQUEST_METHOD + "\n" + this.endpoint + "\n" + REQUEST_URI + "\n" + canonicalQS;
+
+		// get the signature
+		String hmac = this.hmac(toSign);
+		String sig = this.percentEncodeRfc3986(hmac);
+
+		// construct the URL
+		String url = "http://" + this.endpoint + REQUEST_URI + "?" + canonicalQS + "&Signature=" + sig;
+
+		return url;
+	}
+
+	/**
+	 * This method signs requests in query-string form. It returns a URL that
+	 * should be used to fetch the response. The URL returned should not be
+	 * modified in any way, doing so will invalidate the signature and Amazon
+	 * will reject the request.
+	 */
+	public String sign(String queryString) {
+		// let's break the query string into it's constituent name-value pairs
+		Map<String, String> params = this.createParameterMap(queryString);
+
+		// then we can sign the request as before
+		return this.sign(params);
+	}
+
+	/**
+	 * Compute the HMAC.
+	 * 
+	 * @param stringToSign
+	 *            String to compute the HMAC over.
+	 * @return base64-encoded hmac value.
+	 */
+	private String hmac(String stringToSign) {
+		String signature = null;
+		byte[] data;
+		byte[] rawHmac;
+		try {
+			data = stringToSign.getBytes(UTF8_CHARSET);
+			rawHmac = mac.doFinal(data);
+			signature = Base64.getEncoder().encodeToString(rawHmac);
+		} catch (UnsupportedEncodingException e) {
+			throw new RuntimeException(UTF8_CHARSET + " is unsupported!", e);
+		}
+		return signature;
+	}
+
+	/**
+	 * Generate a ISO-8601 format timestamp as required by Amazon.
+	 * 
+	 * @return ISO-8601 format timestamp.
+	 */
+	private String timestamp() {
+		String timestamp = null;
+		Calendar cal = Calendar.getInstance();
+		DateFormat dfm = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+		dfm.setTimeZone(TimeZone.getTimeZone("GMT"));
+		timestamp = dfm.format(cal.getTime());
+		return timestamp;
+	}
+
+	/**
+	 * Canonicalize the query string as required by Amazon.
+	 * 
+	 * @param sortedParamMap
+	 *            Parameter name-value pairs in lexicographical order.
+	 * @return Canonical form of query string.
+	 */
+	private String canonicalize(SortedMap<String, String> sortedParamMap) {
+		if (sortedParamMap.isEmpty()) {
+			return "";
+		}
+
+		StringBuffer buffer = new StringBuffer();
+		Iterator<Map.Entry<String, String>> iter = sortedParamMap.entrySet().iterator();
+
+		while (iter.hasNext()) {
+			Map.Entry<String, String> kvpair = iter.next();
+			buffer.append(percentEncodeRfc3986(kvpair.getKey()));
+			buffer.append("=");
+			buffer.append(percentEncodeRfc3986(kvpair.getValue()));
+			if (iter.hasNext()) {
+				buffer.append("&");
+			}
+		}
+		String cannoical = buffer.toString();
+		return cannoical;
+	}
+
+	/**
+	 * Percent-encode values according the RFC 3986. The built-in Java
+	 * URLEncoder does not encode according to the RFC, so we make the extra
+	 * replacements.
+	 * 
+	 * @param s
+	 *            decoded string
+	 * @return encoded string per RFC 3986
+	 */
+	private String percentEncodeRfc3986(String s) {
+		String out;
+		try {
+			out = URLEncoder.encode(s, UTF8_CHARSET).replace("+", "%20").replace("*", "%2A").replace("%7E", "~");
+		} catch (UnsupportedEncodingException e) {
+			out = s;
+		}
+		return out;
+	}
+
+	/**
+	 * Takes a query string, separates the constituent name-value pairs and
+	 * stores them in a hashmap.
+	 * 
+	 * @param queryString
+	 * @return
+	 */
+	private Map<String, String> createParameterMap(String queryString) {
+		Map<String, String> map = new HashMap<String, String>();
+		String[] pairs = queryString.split("&");
+
+		for (String pair : pairs) {
+			if (pair.length() < 1) {
+				continue;
+			}
+
+			String[] tokens = pair.split("=", 2);
+			for (int j = 0; j < tokens.length; j++) {
+				try {
+					tokens[j] = URLDecoder.decode(tokens[j], UTF8_CHARSET);
+				} catch (UnsupportedEncodingException e) {
+				}
+			}
+			switch (tokens.length) {
+			case 1: {
+				if (pair.charAt(0) == '=') {
+					map.put("", tokens[0]);
+				} else {
+					map.put(tokens[0], "");
+				}
+				break;
+			}
+			case 2: {
+				map.put(tokens[0], tokens[1]);
+				break;
+			}
+			default: {
+				// nothing
+				break;
+			}
+			}
+		}
+		return map;
+	}
+}


### PR DESCRIPTION
@mariobehling @Orbiter 

I have implemented one part of the Amazon Product Advertising API integration, the ItemLookup API. 

Supply an ASIN / Product ID, and if the product is in the database (and if it's approved by it's parent company to be displayed by the API), it gives you necessary info about the result.

For searches like Apple Products (I did a search on iPhone), it isn't available in the Advertising API, because Apple does not want to display the prices of its products that way or something.

If you wish to test, please contact me. I have the AWS Keys and the Associate Tags, which I can't display here right now. I think these fields should be supplied as a GET parameter instead.

TODO:

* [x] Make it more efficient. The Amazon API is a SOAP API, not REST. Some parameters are available in some products, some aren't.

* [x] Have a feature to list other variants of the product, and possibly list the cheapest variant too.

* [x] Add the SimilarityLookup and ItemSearch API (in ItemSearch, you have Search by Product Name).

Screenshot: 

<img width="869" alt="screen shot 2016-08-06 at 5 01 01 pm" src="https://cloud.githubusercontent.com/assets/14081800/17456509/6799a5d2-5bf7-11e6-9fb6-5b3f44028fd4.png">

