### PR TITLE
Revert travis to default distribution (because of build errors)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
 language: java
-sudo: required
-dist: trusty
 jdk:
 - oraclejdk8
-- openjdk8
 env:
   global:
   - secure: DbveaxDMtEP+/Er6ktKCP+P42uDU8xXWRBlVGaqVNU3muaRmmZtj8ngAARxfzY0f9amlJlCavqkEIAumQl9BYKPWIra28ylsLNbzAoCIi8alf9WLgddKwVWsTcZo9+UYocuY6UivJVkofycfFJ1blw/83dWMG0/TiW6s/SrwoDw=


### PR DESCRIPTION
This reverts https://github.com/loklak/loklak_server/pull/784 as there are some build errors since yesterday