### PR TITLE
Declare project name for Gradle

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'loklak_server'


### PR DESCRIPTION
It's a good idea to declare a project name for Gradle so it doesn't
assume the working directory (the directory where the local git repo
is at) as the project name.
