### PR TITLE
Define source and target compability to 1.8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,8 @@
 apply plugin: 'java'
 
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
+
 jar {
     manifest {
         attributes 'Main-Class': 'org.loklak.LoklakServer'


### PR DESCRIPTION
In the Ant build.xml, It defines the source and target compatibility to
1.8. For consistency sake, It's a good idea to set the same thing on
Gradle as well
