### PR TITLE
Add Gradle generated classes to the classpath

### DIFF
--- a/bin/start.bat
+++ b/bin/start.bat
@@ -1,3 +1,3 @@
 cd ..
-START java -Xmx4G -Xms1G -server -XX:+AggressiveOpts -XX:NewSize=512M -cp "classes;lib/*" org.loklak.LoklakServer >> data/loklak.log 2>&1 & echo $! > data/loklak.pid
+START java -Xmx4G -Xms1G -server -XX:+AggressiveOpts -XX:NewSize=512M -cp "classes;build/classes/main;lib/*" org.loklak.LoklakServer >> data/loklak.log 2>&1 & echo $! > data/loklak.pid
 echo "loklak server started at port 9000, open your browser at http://localhost:9000"

--- a/bin/start.sh
+++ b/bin/start.sh
@@ -70,17 +70,17 @@ CLASSPATH=""
 for N in lib/*.jar; do CLASSPATH="$CLASSPATH$N:"; done
 
 if [ -d "./classes" ]; then
-	CLASSPATH=".:./classes/:$CLASSPATH"
+    CLASSPATH=".:./classes/:$CLASSPATH"
 elif [ -d "./build/classes/main" ]; then
-	CLASSPATH=".:./build/classes/main:$CLASSPATH"
+    CLASSPATH=".:./build/classes/main:$CLASSPATH"
 else
-	echo "It seems you haven't compile Loklak"
-	echo "You can use either Gradle or Ant to build Loklak"
-	echo "If you want to build with Ant,"
-       	echo "$ ant"
-	echo "If you want to build with Gradle,"
-	echo "$ ./gradle_init.sh && gradle build"
-	exit 1	
+    echo "It seems you haven't compile Loklak"
+    echo "You can use either Gradle or Ant to build Loklak"
+    echo "If you want to build with Ant,"
+    echo "$ ant"
+    echo "If you want to build with Gradle,"
+    echo "$ ./gradle_init.sh && gradle build"
+    exit 1	
 fi
 
 cmdline="java";

--- a/bin/start.sh
+++ b/bin/start.sh
@@ -68,7 +68,20 @@ fi
 
 CLASSPATH=""
 for N in lib/*.jar; do CLASSPATH="$CLASSPATH$N:"; done
-CLASSPATH=".:./classes/:$CLASSPATH"
+
+if [ -d "./classes" ]; then
+	CLASSPATH=".:./classes/:$CLASSPATH"
+elif [ -d "./build/classes/main" ]; then
+	CLASSPATH=".:./build/classes/main:$CLASSPATH"
+else
+	echo "It seems you haven't compile Loklak"
+	echo "You can use either Gradle or Ant to build Loklak"
+	echo "If you want to build with Ant,"
+       	echo "$ ant"
+	echo "If you want to build with Gradle,"
+	echo "$ ./gradle_init.sh && gradle build"
+	exit 1	
+fi
 
 cmdline="java";
 


### PR DESCRIPTION
Some people may prefer to use Gradle over Ant to build Loklak so It's a
good idea to add Gradle's generated classes to the classpath of start.sh
and start.bat