### PR TITLE
Removed ant error

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,8 +10,15 @@ RUN apt-get upgrade -y
 RUN apt-get install -y git ant openjdk-8-jdk
 
 # clone the github repo
-RUN git clone https://github.com/loklak/loklak_server.git
+RUN git clone --depth 1 https://github.com/loklak/loklak_server.git
 WORKDIR loklak_server
+
+RUN locale-gen en_US.UTF-8
+RUN update-locale LANG=en_US.UTF-8 LC_MESSAGES=POSIX
+ENV LANG en_US.UTF-8
+ENV LC_MESSAGES POSIX
+RUN locale
+
 
 # compile
 RUN ant
@@ -25,7 +32,7 @@ RUN sed -i.bak 's/^\(port.https=\).*/\1443/'              conf/config.properties
 RUN sed -i.bak 's/^\(upgradeInterval=\).*/\186400000000/' conf/config.properties
 
 # hack until loklak support no-daemon
-RUN echo "while true; do sleep 10;done" >> bin/start.sh
+COPY docker-cmd.sh docker-cmd.sh
 
 # start loklak
-CMD ["bin/start.sh"]
+CMD ["./docker-cmd.sh"]

--- a/docker/docker-cmd.sh
+++ b/docker/docker-cmd.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+bin/start.sh
+
+while true
+  do sleep 10
+done


### PR DESCRIPTION
Problem: ant was not building. The locale was set to POSIX.
Solution: set the locale to en_US.utf8

Problem: The build context delays the docker build
Solution: Move the Dockerfile into its own folder so it does not copy all files.

Problem: The git repository is big and cloning takes a long time.
Solution: Dockerfile clones only the latest commit.

This fixes #849 

To make this change an automated build, you need to change the [settings on docker hub](https://hub.docker.com/r/mariobehling/loklak/~/settings/automated-builds/) like this:
![capture](https://cloud.githubusercontent.com/assets/564768/20034002/1ef2f8c8-a3b0-11e6-8dbd-158ac2463655.PNG)

Your suggestions are welcome.
