### PR TITLE
Gradle: Declare source set instead of using scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,8 @@ env:
   - secure: DbveaxDMtEP+/Er6ktKCP+P42uDU8xXWRBlVGaqVNU3muaRmmZtj8ngAARxfzY0f9amlJlCavqkEIAumQl9BYKPWIra28ylsLNbzAoCIi8alf9WLgddKwVWsTcZo9+UYocuY6UivJVkofycfFJ1blw/83dWMG0/TiW6s/SrwoDw=
 install:
 - pip install --user flake8
-script:
-- "./gradle_init.sh"
-- gradle assemble
-- "./gradle_clean.sh"
+- gradle build
+- gradle clean
 - ant
 - bin/start.sh
 # Run flake8

--- a/README.md
+++ b/README.md
@@ -129,23 +129,19 @@ Hey, this is the tool for that! Just put http://loklak.org/api/search.rss?q=%23l
   ```
   brew install gradle
   ```
-- To compile, first, create dir necessary for Gradle
-
-  ```
-  ./gradle_init.sh
-  ```
 
   Compile the source to classes and a jar file
 
   ```
-  gradle assemble
+  gradle build
   ```
 
   Compiled file can be found in build dir
-  Last, clean up so that we can still build the project using Ant
+  
+  To remove compiled classes and jar file
 
   ```
-  ./gradle_clean.sh
+  gradle clean
   ```
 
 

--- a/bin/start.sh
+++ b/bin/start.sh
@@ -79,7 +79,7 @@ else
     echo "If you want to build with Ant,"
     echo "$ ant"
     echo "If you want to build with Gradle,"
-    echo "$ ./gradle_init.sh && gradle build"
+    echo "$ gradle build"
     exit 1
 fi
 

--- a/build.gradle
+++ b/build.gradle
@@ -3,16 +3,18 @@ apply plugin: 'java'
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
+sourceSets.main.java.srcDirs = ['src']
+
 jar {
-    manifest {
-        attributes 'Main-Class': 'org.loklak.LoklakServer'
-    }
+  manifest {
+    attributes 'Main-Class': 'org.loklak.LoklakServer'
+  }
 }
 
 repositories {
-    flatDir {
-        dirs 'lib'
-    }
+  flatDir {
+    dirs 'lib'
+  }
 }
 
 dependencies {

--- a/gradle_clean.sh
+++ b/gradle_clean.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-rm -rf .grade/
-rm -rf build/
-rm -rf src/main/

--- a/gradle_init.sh
+++ b/gradle_init.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-mkdir src/main
-mkdir src/main/java
-cp -r src/org/ src/main/java/org


### PR DESCRIPTION
This commit remove the requirement of running the `gradle_init.sh`
script and declare the source folder to the existing one.

Closes https://github.com/loklak/loklak_server/issues/878