### PR TITLE
Add Gradle generated classes to classpath

### DIFF
--- a/bin/bluemix_start.sh
+++ b/bin/bluemix_start.sh
@@ -21,7 +21,20 @@ fi
 
 CLASSPATH=""
 for N in lib/*.jar; do CLASSPATH="$CLASSPATH$N:"; done
-CLASSPATH=".:./classes/:$CLASSPATH"
+
+if [ -d "./classes" ]; then
+    CLASSPATH=".:./classes/:$CLASSPATH"
+elif [ -d "./build/classes/main" ]; then
+    CLASSPATH=".:./build/classes/main:$CLASSPATH"
+else
+    echo "It seems you haven't compile Loklak"
+    echo "You can use either Gradle or Ant to build Loklak"
+    echo "If you want to build with Ant,"
+    echo "$ ant"
+    echo "If you want to build with Gradle,"
+    echo "$ gradle build"
+    exit 1
+fi
 
 cmdline="java";
 

--- a/bin/heroku_start.sh
+++ b/bin/heroku_start.sh
@@ -21,7 +21,20 @@ fi
 
 CLASSPATH=""
 for N in lib/*.jar; do CLASSPATH="$CLASSPATH$N:"; done
-CLASSPATH=".:./classes/:$CLASSPATH"
+
+if [ -d "./classes" ]; then
+    CLASSPATH=".:./classes/:$CLASSPATH"
+elif [ -d "./build/classes/main" ]; then
+    CLASSPATH=".:./build/classes/main:$CLASSPATH"
+else
+    echo "It seems you haven't compile Loklak"
+    echo "You can use either Gradle or Ant to build Loklak"
+    echo "If you want to build with Ant,"
+    echo "$ ant"
+    echo "If you want to build with Gradle,"
+    echo "$ gradle build"
+    exit 1
+fi
 
 cmdline="java";
 

--- a/bin/installation.sh
+++ b/bin/installation.sh
@@ -34,7 +34,20 @@ fi
 
 CLASSPATH=""
 for N in lib/*.jar; do CLASSPATH="$CLASSPATH$N:"; done
-CLASSPATH=".:./classes/:$CLASSPATH"
+
+if [ -d "./classes" ]; then
+    CLASSPATH=".:./classes/:$CLASSPATH"
+elif [ -d "./build/classes/main" ]; then
+    CLASSPATH=".:./build/classes/main:$CLASSPATH"
+else
+    echo "It seems you haven't compile Loklak"
+    echo "You can use either Gradle or Ant to build Loklak"
+    echo "If you want to build with Ant,"
+    echo "$ ant"
+    echo "If you want to build with Gradle,"
+    echo "$ gradle build"
+    exit 1
+fi
 
 cmdline="java";
 


### PR DESCRIPTION
Some of the scripts doesn't include the Gradle generated classes to
the classpath. This commit adds the classes and checks the
availability of ant or gradle generated classes.

Closes https://github.com/loklak/loklak_server/issues/873