### PR TITLE
Reduce redundancy and code duplication on shell scripts

### DIFF
--- a/bin/.preload.sh
+++ b/bin/.preload.sh
@@ -30,3 +30,27 @@ if [ -f $CUSTOMCONFIG ]; then
     j="$(grep Xmx $CUSTOMCONFIG | sed 's/^[^=]*=//')";
     if [ -n $j ]; then CUSTOMXmx="$j"; fi;
 fi
+
+CLASSPATH=""
+for N in lib/*.jar; do CLASSPATH="$CLASSPATH$N:"; done
+
+if [ -d "./classes" ]; then
+    CLASSPATH=".:./classes/:$CLASSPATH"
+elif [ -d "./build/classes/main" ]; then
+    CLASSPATH=".:./build/classes/main:$CLASSPATH"
+else
+    echo "It seems you haven't compile Loklak"
+    echo "You can use either Gradle or Ant to build Loklak"
+    echo "If you want to build with Ant,"
+    echo "$ ant"
+    echo "If you want to build with Gradle,"
+    echo "$ gradle build"
+    exit 1
+fi
+
+cmdline="java";
+
+if [ -n "$ENVXmx" ] ; then cmdline="$cmdline -Xmx$ENVXmx";
+elif [ -n "$CUSTOMXmx" ]; then cmdline="$cmdline -Xmx$CUSTOMXmx";
+elif [ -n "$DFAULTXmx" ]; then cmdline="$cmdline -Xmx$DFAULTXmx";
+fi

--- a/bin/.preload.sh
+++ b/bin/.preload.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+INSTALLATIONCONFIG="data/settings/installation.txt"
+PIDFILE="data/loklak.pid"
+DFAULTCONFIG="conf/config.properties"
+CUSTOMCONFIG="data/settings/customized_config.properties"
+LOGCONFIG="conf/logs/log-to-file.properties"
+STARTUPFILE="data/startup.tmp"
+DFAULTXmx="-Xmx800m";
+CUSTOMXmx=""

--- a/bin/.preload.sh
+++ b/bin/.preload.sh
@@ -21,3 +21,12 @@ if [ -f $PIDFILE ]; then
         rm $PIDFILE
     fi
 fi
+
+if [ -f $DFAULTCONFIG ]; then
+    j="$(grep Xmx $DFAULTCONFIG | sed 's/^[^=]*=//')";
+    if [ -n $j ]; then DFAULTXmx="$j"; fi;
+fi
+if [ -f $CUSTOMCONFIG ]; then
+    j="$(grep Xmx $CUSTOMCONFIG | sed 's/^[^=]*=//')";
+    if [ -n $j ]; then CUSTOMXmx="$j"; fi;
+fi

--- a/bin/.preload.sh
+++ b/bin/.preload.sh
@@ -8,3 +8,16 @@ LOGCONFIG="conf/logs/log-to-file.properties"
 STARTUPFILE="data/startup.tmp"
 DFAULTXmx="-Xmx800m";
 CUSTOMXmx=""
+
+mkdir -p data/settings
+
+#to not allow process to overwrite the already running one.
+if [ -f $PIDFILE ]; then
+    PID=$(cat $PIDFILE 2>/dev/null)
+    if [ $(ps -p $PID -o pid=) ]; then
+        echo "Server is already running, please stop it and then start"
+        exit 1
+    else
+        rm $PIDFILE
+    fi
+fi

--- a/bin/bluemix_start.sh
+++ b/bin/bluemix_start.sh
@@ -1,48 +1,7 @@
-#!/usr/bin/env sh
-cd `dirname $0`/..
-mkdir -p data
+#!/usr/bin/env bash
 
-DFAULTCONFIG="conf/config.properties"
-CUSTOMCONFIG="data/settings/customized_config.properties"
-LOGCONFIG="conf/logs/log4j2.properties"
-DFAULTXmx="-Xmx800m";
-CUSTOMXmx=""
-if [ -f $DFAULTCONFIG ]; then
- j="`grep Xmx $DFAULTCONFIG | sed 's/^[^=]*=//'`";
- if [ -n $j ]; then DFAULTXmx="$j"; fi;
-fi
-if [ -f $CUSTOMCONFIG ]; then
- j="`grep Xmx $CUSTOMCONFIG | sed 's/^[^=]*=//'`";
- if [ -n $j ]; then CUSTOMXmx="$j"; fi;
-fi
-
-#echo "DFAULTXmx: !$DFAULTXmx!"
-#echo "CUSTOMXmx: !$CUSTOMXmx!"
-
-CLASSPATH=""
-for N in lib/*.jar; do CLASSPATH="$CLASSPATH$N:"; done
-
-if [ -d "./classes" ]; then
-    CLASSPATH=".:./classes/:$CLASSPATH"
-elif [ -d "./build/classes/main" ]; then
-    CLASSPATH=".:./build/classes/main:$CLASSPATH"
-else
-    echo "It seems you haven't compile Loklak"
-    echo "You can use either Gradle or Ant to build Loklak"
-    echo "If you want to build with Ant,"
-    echo "$ ant"
-    echo "If you want to build with Gradle,"
-    echo "$ gradle build"
-    exit 1
-fi
-
-cmdline="java";
-
-if [ -n "$ENVXmx" ] ; then cmdline="$cmdline -Xmx$ENVXmx";
-elif [ -n "$CUSTOMXmx" ]; then cmdline="$cmdline -Xmx$CUSTOMXmx";
-elif [ -n "$DFAULTXmx" ]; then cmdline="$cmdline -Xmx$DFAULTXmx";
-fi
-
+# Make sure we're on project root
+cd $(dirname $0)/..
 
 #jdk8
 
@@ -74,12 +33,4 @@ cd $PWD
 export JAVA_HOME="$PWD/.jdk8"
 export PATH="$JAVA_HOME/bin:$PATH"
 
-
-echo "starting loklak"
-
-cmdline="$cmdline -server -classpath $CLASSPATH -Dlog4j.configurationFile=$LOGCONFIG org.loklak.LoklakServer";
-
-eval $cmdline
-#echo $cmdline;
-
-echo "loklak server started at port 9000, open your browser at http://localhost:9000"
+exec ./bin/start.sh -Id

--- a/bin/heroku_start.sh
+++ b/bin/heroku_start.sh
@@ -1,53 +1,6 @@
-#!/usr/bin/env sh
-cd `dirname $0`/..
-mkdir -p data
+#!/usr/bin/env bash
 
-DFAULTCONFIG="conf/config.properties"
-CUSTOMCONFIG="data/settings/customized_config.properties"
-LOGCONFIG="conf/logs/log4j2.properties"
-DFAULTXmx="-Xmx800m";
-CUSTOMXmx=""
-if [ -f $DFAULTCONFIG ]; then
- j="`grep Xmx $DFAULTCONFIG | sed 's/^[^=]*=//'`";
- if [ -n $j ]; then DFAULTXmx="$j"; fi;
-fi
-if [ -f $CUSTOMCONFIG ]; then
- j="`grep Xmx $CUSTOMCONFIG | sed 's/^[^=]*=//'`";
- if [ -n $j ]; then CUSTOMXmx="$j"; fi;
-fi
+# Make sure we're on project root
+cd $(dirname $0)/..
 
-#echo "DFAULTXmx: !$DFAULTXmx!"
-#echo "CUSTOMXmx: !$CUSTOMXmx!"
-
-CLASSPATH=""
-for N in lib/*.jar; do CLASSPATH="$CLASSPATH$N:"; done
-
-if [ -d "./classes" ]; then
-    CLASSPATH=".:./classes/:$CLASSPATH"
-elif [ -d "./build/classes/main" ]; then
-    CLASSPATH=".:./build/classes/main:$CLASSPATH"
-else
-    echo "It seems you haven't compile Loklak"
-    echo "You can use either Gradle or Ant to build Loklak"
-    echo "If you want to build with Ant,"
-    echo "$ ant"
-    echo "If you want to build with Gradle,"
-    echo "$ gradle build"
-    exit 1
-fi
-
-cmdline="java";
-
-if [ -n "$ENVXmx" ] ; then cmdline="$cmdline -Xmx$ENVXmx";
-elif [ -n "$CUSTOMXmx" ]; then cmdline="$cmdline -Xmx$CUSTOMXmx";
-elif [ -n "$DFAULTXmx" ]; then cmdline="$cmdline -Xmx$DFAULTXmx";
-fi
-
-echo "starting loklak"
-
-cmdline="$cmdline -server -classpath $CLASSPATH -Dlog4j.configurationFile=$LOGCONFIG org.loklak.LoklakServer";
-
-eval $cmdline
-#echo $cmdline;
-
-echo "loklak server started at port 9000, open your browser at http://localhost:9000"
+exec ./bin/start.sh -Id

--- a/bin/installation.sh
+++ b/bin/installation.sh
@@ -8,15 +8,6 @@ cd $(dirname $0)/..
 # Execute preload script
 source bin/.preload.sh
 
-if [ -f $DFAULTCONFIG ]; then
-    j="$(grep Xmx $DFAULTCONFIG | sed 's/^[^=]*=//')";
-    if [ -n $j ]; then DFAULTXmx="$j"; fi;
-fi
-if [ -f $CUSTOMCONFIG ]; then
-    j="$(grep Xmx $CUSTOMCONFIG | sed 's/^[^=]*=//')";
-    if [ -n $j ]; then CUSTOMXmx="$j"; fi;
-fi
-
 CLASSPATH=""
 for N in lib/*.jar; do CLASSPATH="$CLASSPATH$N:"; done
 

--- a/bin/installation.sh
+++ b/bin/installation.sh
@@ -8,19 +8,6 @@ cd $(dirname $0)/..
 # Execute preload script
 source bin/.preload.sh
 
-mkdir -p data
-
-#to not allow process to overwrite the already running one.
-if [ -f $PIDFILE ]; then
-	PID=$(cat $PIDFILE 2>/dev/null)
-	if [ $(ps -p $PID -o pid=) ]; then
-		echo "Server is already running, please stop it and then start"
-		exit 1
-	else
-		rm $PIDFILE
-	fi
-fi
-
 if [ -f $DFAULTCONFIG ]; then
     j="$(grep Xmx $DFAULTCONFIG | sed 's/^[^=]*=//')";
     if [ -n $j ]; then DFAULTXmx="$j"; fi;

--- a/bin/installation.sh
+++ b/bin/installation.sh
@@ -8,30 +8,6 @@ cd $(dirname $0)/..
 # Execute preload script
 source bin/.preload.sh
 
-CLASSPATH=""
-for N in lib/*.jar; do CLASSPATH="$CLASSPATH$N:"; done
-
-if [ -d "./classes" ]; then
-    CLASSPATH=".:./classes/:$CLASSPATH"
-elif [ -d "./build/classes/main" ]; then
-    CLASSPATH=".:./build/classes/main:$CLASSPATH"
-else
-    echo "It seems you haven't compile Loklak"
-    echo "You can use either Gradle or Ant to build Loklak"
-    echo "If you want to build with Ant,"
-    echo "$ ant"
-    echo "If you want to build with Gradle,"
-    echo "$ gradle build"
-    exit 1
-fi
-
-cmdline="java";
-
-if [ -n "$ENVXmx" ] ; then cmdline="$cmdline -Xmx$ENVXmx";
-elif [ -n "$CUSTOMXmx" ]; then cmdline="$cmdline -Xmx$CUSTOMXmx";
-elif [ -n "$DFAULTXmx" ]; then cmdline="$cmdline -Xmx$DFAULTXmx";
-fi
-
 echo "starting loklak installation"
 echo "startup" > $STARTUPFILE
 

--- a/bin/installation.sh
+++ b/bin/installation.sh
@@ -1,15 +1,13 @@
 #!/usr/bin/env bash
 
-INSTALLATIONCONFIG="data/settings/installation.txt"
-PIDFILE="data/loklak.pid"
-DFAULTCONFIG="conf/config.properties"
-CUSTOMCONFIG="data/settings/customized_config.properties"
-LOGCONFIG="conf/logs/log-to-file.properties"
-STARTUPFILE="data/startup.tmp"
-DFAULTXmx="-Xmx800m";
-CUSTOMXmx=""
+# If you're looking for the variables, please go to bin/.preload.sh
 
+# Make sure we're on project root
 cd $(dirname $0)/..
+
+# Execute preload script
+source bin/.preload.sh
+
 mkdir -p data
 
 #to not allow process to overwrite the already running one.

--- a/bin/start.sh
+++ b/bin/start.sh
@@ -41,15 +41,6 @@ if [ ! -f $INSTALLATIONCONFIG ]; then
 OPTIONAL
 fi
 
-if [ -f $DFAULTCONFIG ]; then
-    j="$(grep Xmx $DFAULTCONFIG | sed 's/^[^=]*=//')";
-    if [ -n $j ]; then DFAULTXmx="$j"; fi;
-fi
-if [ -f $CUSTOMCONFIG ]; then
-    j="$(grep Xmx $CUSTOMCONFIG | sed 's/^[^=]*=//')";
-    if [ -n $j ]; then CUSTOMXmx="$j"; fi;
-fi
-
 CLASSPATH=""
 for N in lib/*.jar; do CLASSPATH="$CLASSPATH$N:"; done
 

--- a/bin/start.sh
+++ b/bin/start.sh
@@ -8,20 +8,6 @@ cd $(dirname $0)/..
 # Execute preload script
 source bin/.preload.sh
 
-mkdir -p data/settings
-
-#to not allow process to overwrite the already running one.
-if [ -f $PIDFILE ]; then
-    PID=$(cat $PIDFILE 2>/dev/null)
-    if [ $(ps -p $PID -o pid=) ]; then
-        echo "Server is already running, please stop it and then start"
-        exit 1
-    else
-        rm $PIDFILE
-    fi
-fi
-
-
 # installation
 if [ ! -f $INSTALLATIONCONFIG ]; then
     echo "Loklak detected that you did not yet run the installation wizard."

--- a/bin/start.sh
+++ b/bin/start.sh
@@ -41,30 +41,6 @@ if [ ! -f $INSTALLATIONCONFIG ]; then
 OPTIONAL
 fi
 
-CLASSPATH=""
-for N in lib/*.jar; do CLASSPATH="$CLASSPATH$N:"; done
-
-if [ -d "./classes" ]; then
-    CLASSPATH=".:./classes/:$CLASSPATH"
-elif [ -d "./build/classes/main" ]; then
-    CLASSPATH=".:./build/classes/main:$CLASSPATH"
-else
-    echo "It seems you haven't compile Loklak"
-    echo "You can use either Gradle or Ant to build Loklak"
-    echo "If you want to build with Ant,"
-    echo "$ ant"
-    echo "If you want to build with Gradle,"
-    echo "$ gradle build"
-    exit 1
-fi
-
-cmdline="java";
-
-if [ -n "$ENVXmx" ] ; then cmdline="$cmdline -Xmx$ENVXmx";
-elif [ -n "$CUSTOMXmx" ]; then cmdline="$cmdline -Xmx$CUSTOMXmx";
-elif [ -n "$DFAULTXmx" ]; then cmdline="$cmdline -Xmx$DFAULTXmx";
-fi
-
 echo "starting loklak"
 echo "startup" > $STARTUPFILE
 

--- a/bin/start.sh
+++ b/bin/start.sh
@@ -1,14 +1,13 @@
 #!/usr/bin/env bash
 
-PIDFILE="data/loklak.pid"
-DFAULTCONFIG="conf/config.properties"
-CUSTOMCONFIG="data/settings/customized_config.properties"
-LOGCONFIG="conf/logs/log-to-file.properties"
-STARTUPFILE="data/startup.tmp"
-DFAULTXmx="-Xmx800m";
-CUSTOMXmx=""
+# If you're looking for the variables, please go to bin/.preload.sh
 
+# Make sure we're on project root
 cd $(dirname $0)/..
+
+# Execute preload script
+source bin/.preload.sh
+
 mkdir -p data/settings
 
 #to not allow process to overwrite the already running one.
@@ -24,7 +23,6 @@ fi
 
 
 # installation
-INSTALLATIONCONFIG="data/settings/installation.txt"
 if [ ! -f $INSTALLATIONCONFIG ]; then
     echo "Loklak detected that you did not yet run the installation wizard."
     echo "It let's you setup an administrator account and a number of settings, but is not mandatory."


### PR DESCRIPTION
The shell scripts which are used to start/stop Loklak has a huge
amount of duplicate code. This commit reduces the amount of redundancy
and duplication by separating them into it's own script.

Fixes https://github.com/loklak/loklak_server/issues/886