### PR TITLE
Heroku: Display logs after loklak starts

### DIFF
--- a/bin/heroku_start.sh
+++ b/bin/heroku_start.sh
@@ -3,4 +3,6 @@
 # Make sure we're on project root
 cd $(dirname $0)/..
 
-exec ./bin/start.sh -Id
+eval ./bin/start.sh -Id
+
+tail -f data/loklak.log


### PR DESCRIPTION
Heroku thinks loklak crashed because the start script exited before
Loklak, even though Loklak just daemonized.

To prevent this, it's better to display Loklak's log.

Fixes https://github.com/loklak/loklak_server/issues/860

### Short description
I have:
- [x] There is a corresponding issue for this pull request.
- [x] Mentioned the Issue number in the pull request commit message `Fixes #<number> commit message`
- [x] There is only strictly only one commit per issue.

### For the reviewers
I have:
- [x] Reviewed this pull request by an authorized contributor.
- [x] The reviewer is assigned to the pull request.
