### PR TITLE
Add alternative Harvester: Kaizen

### DIFF
--- a/conf/config.properties
+++ b/conf/config.properties
@@ -256,4 +256,7 @@ classification.language.dutch=de,van,een,het,en,in,is,dat,op,te,De,zijn,voor,met
 flag.fixunshorten = false
 flag.replaceinsteadunshorten = false
 
-
+# harvester to use
+# possible values:
+#   - classic: The default and original Loklak Harvester
+harvester.type = classic

--- a/conf/config.properties
+++ b/conf/config.properties
@@ -259,4 +259,22 @@ flag.replaceinsteadunshorten = false
 # harvester to use
 # possible values:
 #   - classic: The default and original Loklak Harvester
+#   - kaizen: The alternative Loklak Harvester that can utilize Twitter API (optional)
 harvester.type = classic
+
+# Configurations for kaizen harvester
+
+# The amount of suggestions to request
+harvester.kaizen.suggestions_count = 1000
+
+# The amount of randomly selected suggestions to add
+harvester.kaizen.suggestions_random = 5
+
+# The radius for location/place queries (in miles)
+harvester.kaizen.place_radius = 5
+
+# The query limit (setting this to 0 or below means infinite)
+harvester.kaizen.queries_limit = 500
+
+# Verbosity (gives information to logs, if enabled)
+harvester.kaizen.verbose = true

--- a/src/org/loklak/Caretaker.java
+++ b/src/org/loklak/Caretaker.java
@@ -156,7 +156,7 @@ public class Caretaker extends Thread {
                     for (int j = 0; j < retrieval_forbackend_concurrency; j++) {
                         rts[j] = new Thread() {
                             public void run() {
-                                int count = Harvester.harvest();
+                                int count = LoklakServer.harvester.harvest();
                                 acccount.addAndGet(count);
                             }
                         };

--- a/src/org/loklak/LoklakEmailHandler.java
+++ b/src/org/loklak/LoklakEmailHandler.java
@@ -53,7 +53,7 @@ public class LoklakEmailHandler {
         String password = DAO.getConfig("smtp.sender.password", null);
 		String hostname = DAO.getConfig("smtp.host.name", null);
 		String encryption = DAO.getConfig("smtp.host.encryption", null);
-		Long port = DAO.getConfig("smtp.host.port", 0);
+		int port = DAO.getConfig("smtp.host.port", 0);
 		boolean disableCertChecking = DAO.getConfig("smtp.trustselfsignedcerts", false);
 
         if(senderEmail == null || password == null || hostname == null){
@@ -68,7 +68,7 @@ public class LoklakEmailHandler {
 			throw new Exception("Invalid sender ID");
 		}
 
-        Properties props = createProperties(hostname, port.intValue(), encryption, disableCertChecking);
+        Properties props = createProperties(hostname, port, encryption, disableCertChecking);
 
         Session session;
         if ("none".equals(encryption)) {

--- a/src/org/loklak/LoklakServer.java
+++ b/src/org/loklak/LoklakServer.java
@@ -126,6 +126,7 @@ import org.loklak.data.IncomingMessageBuffer;
 import org.loklak.harvester.TwitterScraper;
 import org.loklak.harvester.strategy.ClassicHarvester;
 import org.loklak.harvester.strategy.Harvester;
+import org.loklak.harvester.strategy.KaizenHarvester;
 import org.loklak.http.RemoteAccess;
 import org.loklak.server.APIHandler;
 import org.loklak.server.FileHandler;
@@ -347,6 +348,9 @@ public class LoklakServer {
             default:
             case "classic":
                 harvester = new ClassicHarvester();
+                break;
+            case "kaizen":
+                harvester = new KaizenHarvester();
                 break;
         }
     }

--- a/src/org/loklak/data/DAO.java
+++ b/src/org/loklak/data/DAO.java
@@ -581,6 +581,15 @@ public class DAO {
         }
     }
 
+    public static int getConfig(String key, int default_val) {
+        String value = config.get(key);
+        try {
+            return value == null ? default_val : Integer.parseInt(value);
+        } catch (NumberFormatException e) {
+            return default_val;
+        }
+    }
+
     public static void setConfig(String key, String value) {
         config.put(key, value);
     }

--- a/src/org/loklak/harvester/PushThread.java
+++ b/src/org/loklak/harvester/PushThread.java
@@ -1,0 +1,37 @@
+package org.loklak.harvester;
+
+import org.loklak.api.p2p.PushServlet;
+import org.loklak.data.DAO;
+import org.loklak.objects.Timeline;
+
+public class PushThread implements Runnable {
+    private String peer;
+    private Timeline tl;
+    public PushThread(String peer, Timeline tl) {
+        this.peer = peer;
+        this.tl = tl;
+    }
+    @Override
+    public void run() {
+        boolean success = false;
+        for (int i = 0; i < 5; i++) {
+            try {
+                long start = System.currentTimeMillis();
+                success = PushServlet.push(new String[]{peer}, tl);
+                if (success) {
+                    DAO.log("retrieval of " + tl.size() + " new messages for q = " + tl.getQuery() +
+                            ", pushed to backend synchronously in " + (System.currentTimeMillis() - start) + " ms; amount = " + tl.size());
+                    return;
+                }
+            } catch (Throwable e) {
+                DAO.log("failed synchronous push to backend, attempt " + i);
+                try {Thread.sleep((i + 1) * 3000);} catch (InterruptedException e1) {}
+            }
+        }
+        String q = tl.getQuery();
+        tl.setQuery(null);
+        DAO.outgoingMessages.transmitTimelineToBackend(tl);
+        DAO.log("retrieval of " + tl.size() + " new messages for q = " + q + ", scheduled push");
+    }
+
+}

--- a/src/org/loklak/harvester/strategy/Harvester.java
+++ b/src/org/loklak/harvester/strategy/Harvester.java
@@ -1,0 +1,14 @@
+package org.loklak.harvester.strategy;
+
+public interface Harvester {
+    /**
+     * This method is in-charge of harvesting and scraping messages
+     * @return the amount of messages that was harvested or -1 if it isn't harvesting
+     */
+    int harvest();
+
+    /**
+     * This method is executed when Loklak is shutting down
+     */
+    void stop();
+}

--- a/src/org/loklak/harvester/strategy/KaizenHarvester.java
+++ b/src/org/loklak/harvester/strategy/KaizenHarvester.java
@@ -1,0 +1,201 @@
+package org.loklak.harvester.strategy;
+
+import org.eclipse.jetty.util.log.Log;
+import org.loklak.api.search.SearchServlet;
+import org.loklak.api.search.SuggestServlet;
+import org.loklak.data.DAO;
+import org.loklak.harvester.PushThread;
+import org.loklak.harvester.TwitterAPI;
+import org.loklak.harvester.TwitterScraper;
+import org.loklak.objects.MessageEntry;
+import org.loklak.objects.QueryEntry;
+import org.loklak.objects.ResultList;
+import org.loklak.objects.Timeline;
+import twitter4j.Location;
+import twitter4j.Trend;
+import twitter4j.Twitter;
+import twitter4j.TwitterException;
+
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Random;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+/**
+ * KaizenHarvester
+ *
+ * Kaizen is targeted to do more information and query grabbing, whether it
+ * uses the official Twitter API, meta-data from collected tweets, or the
+ * analysis of tweets.
+ *
+ * @author Kaisar Arkhan, @yuki_is_bored
+ */
+public class KaizenHarvester implements Harvester {
+
+    private final String BACKEND;
+    private final int SUGGESTIONS_COUNT;
+    private final int SUGGESTIONS_RANDOM;
+    private final int PLACE_RADIUS;
+    private final int QUERIES_LIMIT;
+    private final boolean VERBOSE;
+
+    private Random random;
+
+    private HashSet<String> queries = new HashSet<>();
+    private ExecutorService executorService = Executors.newFixedThreadPool(1);
+
+    private Twitter twitter = null;
+
+    public KaizenHarvester() {
+        BACKEND = DAO.getConfig("backend", "http://loklak.org");
+        SUGGESTIONS_COUNT = DAO.getConfig("harvester.kaizen.suggestions_count", 1000);
+        SUGGESTIONS_RANDOM = DAO.getConfig("harvester.kaizen.suggestions_random", 5);
+        PLACE_RADIUS = DAO.getConfig("harvester.kaizen.place_radius", 5);
+        QUERIES_LIMIT = DAO.getConfig("harvester.kaizen.queries_limit", 500);
+        VERBOSE = DAO.getConfig("harvester.kaizen.verbose", true);
+
+        random = new Random();
+
+        twitter = TwitterAPI.getAppTwitterFactory().getInstance();
+
+        if (twitter == null)
+            DAO.log("Kaizen can utilize Twitter API to get more queries, If you want to use it, " +
+                    "Please add Application and Access tokens (twitterAccessToken, twitterAccessTokenSecret, " +
+                    "client.twitterConsumerKey, client.twitterConsumerSecret)");
+    }
+
+    private void addQuery(String query) {
+        if (QUERIES_LIMIT > 0 && queries.size() > QUERIES_LIMIT)
+            return;
+
+        if (queries.contains(query))
+            return;
+
+        if (VERBOSE)
+            DAO.log("Adding '" + query + "' to queries");
+
+        queries.add(query);
+    }
+
+    private void grabInformation(Timeline timeline) {
+        if (VERBOSE)
+            DAO.log("Kaizen is going to grab more information" +
+                    (timeline.getQuery() != null ? " from results of '" + timeline.getQuery() + "'" : ""));
+
+        for (MessageEntry message : timeline) {
+            for (String user : message.getMentions())
+                addQuery("from:" + user);
+
+            for (String hashtag : message.getHashtags())
+                addQuery(hashtag);
+
+            String place = message.getPlaceName();
+            if (!place.isEmpty())
+               addQuery("near:\"" + message.getPlaceName() + "\" within:" + PLACE_RADIUS + "mi");
+        }
+    }
+
+    private void pushToBackend(Timeline timeline) {
+        DAO.log("Pushing " + timeline.size() + " to backend ..." );
+        executorService.execute(new PushThread(BACKEND, timeline));
+    }
+
+    private int harvestMessages() {
+        if (VERBOSE)
+            DAO.log(queries.size() + " available queries, Harvest season!");
+
+        String query = queries.iterator().next();
+        queries.remove(query);
+
+        if (VERBOSE)
+            DAO.log("Kaizen is going to harvest messages with query '" + query + "'");
+
+        Timeline timeline = TwitterScraper.search(query, Timeline.Order.CREATED_AT, true, false, 400);
+
+        if (timeline == null)
+            timeline = new Timeline(Timeline.Order.CREATED_AT);
+
+        if (timeline.size() == 0) {
+            if (VERBOSE)
+                DAO.log(query + " gives us no result, Pushing to backend anyway ...");
+            timeline.setQuery(query);
+            pushToBackend(timeline);
+
+            return -1;
+        }
+
+        if (VERBOSE)
+            DAO.log("'" + query + "' gives us " + timeline.size() + " messages, Pushing to backend ...");
+
+        pushToBackend(timeline);
+
+        grabInformation(timeline);
+
+        return timeline.size();
+    }
+
+    private void grabTrending() {
+        try {
+            if (VERBOSE)
+                DAO.log("Kaizen is going to get trending topics ...");
+
+            for (Location location : twitter.trends().getAvailableTrends())
+                for (Trend trend : twitter.trends().getPlaceTrends(location.getWoeid()).getTrends())
+                    addQuery(trend.getQuery());
+        } catch (TwitterException e) {
+            if (e.getErrorCode() != 88)
+                Log.getLog().warn(e);
+        }
+    }
+
+    private void grabSuggestions() {
+        if (VERBOSE)
+            DAO.log("Kaizen is going to request for queries suggestions from backend ...");
+
+        try {
+            ResultList<QueryEntry> suggestedQueries =
+                    SuggestServlet.suggest(BACKEND, "", "all", SUGGESTIONS_COUNT,
+                            "desc", "retrieval_next", 0, null, "now",
+                            "retrieval_next", SUGGESTIONS_RANDOM);
+
+            if (VERBOSE)
+                DAO.log("Backend gave us " + suggestedQueries.size() + " suggested queries");
+
+            for (QueryEntry query : suggestedQueries) {
+                addQuery(query.getQuery());
+            }
+
+            if (suggestedQueries.size() == 0) {
+                if (VERBOSE)
+                    DAO.log("It looks like backend doesn't have any suggested queries. "+
+                            "Grabbing relevant context from backend collected messages ...");
+
+                Timeline timeline = SearchServlet.search(BACKEND, "", Timeline.Order.CREATED_AT, "cache",
+                        SUGGESTIONS_RANDOM, 0, SearchServlet.backend_hash, 60000);
+
+                grabInformation(timeline);
+            }
+        } catch (IOException e) {
+            Log.getLog().warn(e);
+        }
+
+        if (twitter != null)
+            grabTrending();
+    }
+
+    @Override
+    public int harvest() {
+        if (!queries.isEmpty() && random.nextBoolean())
+            return harvestMessages();
+
+        grabSuggestions();
+
+        return 0;
+    }
+
+    @Override
+    public void stop() {
+        executorService.shutdown();
+    }
+}


### PR DESCRIPTION
Kaizen is an alternative approach to do Harvesting, it focuses on query and information collecting to generate more queries. Kaizen also uses Twitter API to get trending topics to increase the chance of getting relevant or wanted messages (This feature is optional).

I have:
- [x] There is a corresponding issue for this pull request.
- [x] Mentioned the Issue number in the pull request commit message `Fixes #<number> commit message`
- [x] There is only strictly only one commit per issue.

### For the reviewers
I have:
- [ ] Reviewed this pull request by an authorized contributor.
- [ ] The reviewer is assigned to the pull request.
