### PR TITLE
start: Add support for non-daemonize option

### DIFF
--- a/bin/bluemix_start.sh
+++ b/bin/bluemix_start.sh
@@ -33,4 +33,4 @@ cd $PWD
 export JAVA_HOME="$PWD/.jdk8"
 export PATH="$JAVA_HOME/bin:$PATH"
 
-exec ./bin/start.sh -Id
+exec ./bin/start.sh -Idn

--- a/bin/heroku_start.sh
+++ b/bin/heroku_start.sh
@@ -3,6 +3,4 @@
 # Make sure we're on project root
 cd $(dirname $0)/..
 
-eval ./bin/start.sh -Id
-
-tail -f data/loklak.log
+exec ./bin/start.sh -Idn

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,7 +14,6 @@ ADD src /loklak_server/src/
 ADD lib /loklak_server/lib/
 ADD html /loklak_server/html/
 ADD installation /loklak_server/installation/
-ADD docker /loklak_server/docker/
 ADD ssi /loklak_server/ssi/
 ADD build.xml /loklak_server/
 
@@ -34,4 +33,4 @@ RUN apk update && apk add openjdk8 apache-ant git bash && \
 WORKDIR /loklak_server
 
 # start loklak
-CMD ["./docker/docker-cmd.sh"]
+CMD ["/loklak_server/bin/start.sh", "-Idn"]

--- a/docker/docker-cmd.sh
+++ b/docker/docker-cmd.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-cd $(dirname $0)/..
-
-bin/start.sh -I
-
-tail -f data/loklak.log


### PR DESCRIPTION
The start script has been modified to launch Loklak without forking to
the background. The other scripts that are used for services like
Dokcer, Heroku, and Bluemix are modified to launch Loklak without
daemonization making them know the actual program and aware of it's
actual process.

Closes https://github.com/loklak/loklak_server/issues/965

### Short description
I have:
- [x] There is a corresponding issue for this pull request.
- [x] Mentioned the Issue number in the pull request commit message `Fixes #<number> commit message`
- [x] There is only strictly only one commit per issue.

### For the reviewers
I have:
- [x] Reviewed this pull request by an authorized contributor.
- [x] The reviewer is assigned to the pull request.
