### PR TITLE
Fixes #1048: fix execution of search method without query string

### DIFF
--- a/src/org/loklak/api/search/SearchServlet.java
+++ b/src/org/loklak/api/search/SearchServlet.java
@@ -72,6 +72,7 @@ public class SearchServlet extends HttpServlet {
     // possible values: cache, twitter, all
     public static Timeline search(final String protocolhostportstub, final String query, final Timeline.Order order, final String source, final int count, final int timezoneOffset, final String provider_hash, final long timeout) throws IOException {
         Timeline tl = new Timeline(order);
+        if ("".equals(query)) return tl;
         String urlstring = "";
         try {
             urlstring = protocolhostportstub + "/api/search.json?q=" + URLEncoder.encode(query.replace(' ', '+'), "UTF-8") + "&timezoneOffset=" + timezoneOffset + "&maximumRecords=" + count + "&source=" + (source == null ? "all" : source) + "&minified=true&shortlink=false&timeout=" + timeout;


### PR DESCRIPTION
Same lines of code to search a query keeps on executing even if there is no query. 
This fix prevents running of same lines of code without search query again and again.