### PR TITLE
getParameter defined before using it in restpass.js

### DIFF
--- a/html/apps/resetpass/js/resetpass.js
+++ b/html/apps/resetpass/js/resetpass.js
@@ -1,5 +1,17 @@
 $(document).ready(function()
 {
+	function getParameter(theParameter) { 
+    	var params = window.location.search.substr(1).split('&');
+    	
+    	for (var i = 0; i < params.length; i++) {
+    		var p=params[i].split('=');
+    		if (p[0] == theParameter) {
+    			return p[1];
+    		}   
+    	}
+    	return null;
+    }	
+	
 	var passerr = false, confirmerr = false, tokenerr = false;
 
 	// get password parameters
@@ -173,16 +185,5 @@ $(document).ready(function()
     	}
     }
 
-    function getParameter(theParameter) { 
-    	var params = window.location.search.substr(1).split('&');
-    	
-    	for (var i = 0; i < params.length; i++) {
-    		var p=params[i].split('=');
-    		if (p[0] == theParameter) {
-    			return p[1];
-    		}   
-    	}
-    	return null;
-    }
 
 });


### PR DESCRIPTION
### Short description
This is Issue : "getParameter' was used before it was defined (no-use-before-define)" in html/apps/resetpass/js/resetpass.js

I have resolved this issue