### PR TITLE
Docker: Consistent Volume Path

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
              - "80:80"
          #Map volume-folder    
          volumes:
-             - data:/data
+             - data:/loklak_server/data
              
 #Create named volume             
 volumes:


### PR DESCRIPTION
Problem: docker-compose volume path is not the same as the dockerfile volume path
Solution: Set the docker-compose volume path to the dockerfile volume path

You can view the correct path in the Dockerfile:
https://github.com/loklak/loklak_server/blob/7a1f0378dc40ec25eec6083e43558a62408d84e8/Dockerfile#L38
I checked in the container:
```
bash-4.3# ls /loklak_server/
bin              conf             gradlew          settings.gradle
build            data             html             src
build.gradle     gradle           installation     ssi
bash-4.3# ls /
bin            lib            proc           srv            var
dev            loklak_server  root           sys
etc            media          run            tmp
home           mnt            sbin           usr
```
the data directory exists and is filled within `/loklak_server`

### Short description
I have:
- [x] There is a corresponding issue for this pull request. #1051
- [ ] Mentioned the Issue number in the pull request commit message `Fixes #<number> commit message`
- [ ] There is only strictly only one commit per issue.

### For the reviewers
I have:
- [ ] Reviewed this pull request by an authorized contributor.
- [ ] The reviewer is assigned to the pull request.
