### PR TITLE
Added JS EventListener to resize dump iframe on load. Closes #1101

### DIFF
--- a/html/dump.html
+++ b/html/dump.html
@@ -8,6 +8,19 @@
     <title>loklak Dump Download</title>
     <!--#include file="../ssi/common_head_back.include" -->
     <!--#include file="../data/ssi/custom_head.include" -->
+    <script type="application/javascript">
+
+      function resizeIFrameToFitContent( iFrame ) {
+          iFrame.width  = iFrame.contentWindow.document.body.scrollWidth;
+          iFrame.height = iFrame.contentWindow.document.body.scrollHeight;
+      }
+
+      window.addEventListener('DOMContentReady', function(e) {
+        var iFrame = document.getElementById('dump-iframe');
+        resizeIFrameToFitContent( iFrame );
+      });
+
+    </script>
   </head>
 
   <body>
@@ -33,7 +46,7 @@
     </nav>
 
     <div class="container-fluid">
-        <iframe src="dump/" width="99%" height="800" frameBorder="0"></iframe>
+        <iframe src="dump/" width="99%" height="800" frameBorder="0" id="dump-iframe"></iframe>
     </div>
     <!--#include file="../ssi/common_body_back.include" -->
     <!--#include file="../data/ssi/custom_body_back.include" -->


### PR DESCRIPTION
### Short description
I have:
- [x] There is a corresponding issue for this pull request.
- [x] Mentioned the Issue number in the pull request commit message `Fixes #<number> commit message`
- [x] There is only strictly only one commit per issue.

### For the reviewers
I have:
- [ ] Reviewed this pull request by an authorized contributor.
- [ ] The reviewer is assigned to the pull request.

Added JS event listener on `DOMContentReady` which would resize the content according to height and width of the contents of `iframe` in dump.html. Fixes #1101.