### PR TITLE
Include status 30X for URL unshortening

### DIFF
--- a/src/org/loklak/harvester/RedirectUnshortener.java
+++ b/src/org/loklak/harvester/RedirectUnshortener.java
@@ -75,17 +75,22 @@ public class RedirectUnshortener {
     
     public static String unShorten(String urlstring) {
         //long start = System.currentTimeMillis();
+        if (!isApplicable(urlstring)) {
+            return urlstring;
+        }
         try {
             int termination = 10; // loop for recursively shortened urls
-            while (isApplicable(urlstring) && termination-- > 0) {
+            while (termination-- > 0) {
                 String unshortened = ClientConnection.getRedirect(urlstring);
-                if (unshortened.equals(urlstring)) return urlstring;
+                if (unshortened.equals(urlstring)) {
+                    return urlstring;
+                }
                 urlstring = unshortened; // recursive apply unshortener because some unshortener are applied several times
             }
             //DAO.log("UNSHORTENED in " + (System.currentTimeMillis() - start) + " milliseconds: " + urlstring);
             return urlstring;
         } catch (IOException e) {
-            DAO.log("UNSHORTEN failed for " + urlstring);
+            DAO.log("UNSHORTEN failed for " + urlstring + " : " + e);
             return urlstring;
         }
     }


### PR DESCRIPTION
### Include HTTP status `30X` while unshortening
Since any of the HTTP `30X` is may be used by many URL shortening services, it should be also considered while unshortening.

Fixes #1114.

I have:
- [x] There is a corresponding issue for this pull request.
- [x] Mentioned the Issue number in the pull request commit message `Fixes #<number> commit message`
- [x] There is only strictly only one commit per issue.

### For the reviewers
I have:
- [ ] Reviewed this pull request by an authorized contributor.
- [ ] The reviewer is assigned to the pull request.
