### PR TITLE
fix #1130: Make retries and back off parameter for backend push configurable

### DIFF
--- a/conf/config.properties
+++ b/conf/config.properties
@@ -280,3 +280,7 @@ harvester.kaizen.queries_limit = 500
 
 # Verbosity (gives information to logs, if enabled)
 harvester.kaizen.verbose = true
+
+# Caretaker properties
+caretaker.backendpush.retries = 5
+caretaker.backendpush.backoff = 3000


### PR DESCRIPTION
The number of retries and back off parameter can be set from `config.properties` by changing/defining `caretaker.backendpush.retries` and `caretaker.backendpush.backoff` respectively.

Fixes #1130.

### Short description
I have:
- [x] There is a corresponding issue for this pull request.
- [x] Mentioned the Issue number in the pull request commit message `Fixes #<number> commit message`
- [x] There is only strictly only one commit per issue.

### For the reviewers
I have:
- [ ] Reviewed this pull request by an authorized contributor.
- [ ] The reviewer is assigned to the pull request.
