### PR TITLE
fixes #1146: Check for TwitterFactory before getting instance

### DIFF
--- a/src/org/loklak/harvester/strategy/KaizenHarvester.java
+++ b/src/org/loklak/harvester/strategy/KaizenHarvester.java
@@ -14,6 +14,7 @@ import twitter4j.Location;
 import twitter4j.Trend;
 import twitter4j.Twitter;
 import twitter4j.TwitterException;
+import twitter4j.TwitterFactory;
 
 import java.io.IOException;
 import java.text.DateFormat;
@@ -60,7 +61,10 @@ public class KaizenHarvester implements Harvester {
 
         random = new Random();
 
-        twitter = TwitterAPI.getAppTwitterFactory().getInstance();
+        TwitterFactory twitterFactory = TwitterAPI.getAppTwitterFactory();
+
+        if (twitterFactory != null)
+            twitter = twitterFactory.getInstance();
 
         if (twitter == null)
             DAO.log("Kaizen can utilize Twitter API to get more queries, If you want to use it, " +


### PR DESCRIPTION
### Short description
Fixes #1146.

Included check for `twitterFactory` not being null before getting instance to avoid `NullPointerException`.
I have:
- [x] There is a corresponding issue for this pull request.
- [x] Mentioned the Issue number in the pull request commit message `Fixes #<number> commit message`
- [x] There is only strictly only one commit per issue.

### For the reviewers
I have:
- [ ] Reviewed this pull request by an authorized contributor.
- [ ] The reviewer is assigned to the pull request.
