### PR TITLE
fix #1143: Fix NumberException in YoutubeScraper

### DIFF
--- a/src/org/loklak/harvester/YoutubeScraper.java
+++ b/src/org/loklak/harvester/YoutubeScraper.java
@@ -36,6 +36,7 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.loklak.tools.CharacterCoding;
+import org.loklak.data.DAO;
 
 public class YoutubeScraper {
 
@@ -134,17 +135,17 @@ public class YoutubeScraper {
                 if ((p = input.indexOf("yt-subscriber-count")) >= 0) {
                     String subscriber_string = parseProp(input, p, "title");
                     if (subscriber_string == null) continue;
-                    json.put("youtube_subscriber", parseNumber(subscriber_string));
+                    json.put("youtube_subscriber", parseValue(subscriber_string));
                     continue;
                 }
                 if (input.indexOf("\"like this") > 0 && (p = input.indexOf("yt-uix-button-content")) >= 0) {
                     String likes_string = parseTag(input, p);
-                    json.put("youtube_likes", parseNumber(likes_string));
+                    json.put("youtube_likes", parseValue(likes_string));
                     continue;
                 }
                 if (input.indexOf("\"dislike this") > 0 && (p = input.indexOf("yt-uix-button-content")) >= 0) {
                     String dislikes_string = parseTag(input, p);
-                    json.put("youtube_dislikes", parseNumber(dislikes_string));
+                    json.put("youtube_dislikes", parseValue(dislikes_string));
                     continue;
                 }
                 if ((p = input.indexOf("watch-view-count")) >= 0) {
@@ -152,10 +153,7 @@ public class YoutubeScraper {
                     if (viewcount_string == null) continue;
                     viewcount_string = viewcount_string.replace(" views", "");
                     if (viewcount_string.length() == 0) continue;
-                    long viewcount = 0;
-                    // if there are no views, there may be a string saying "No". But this is done in all languages, so we just catch a NumberFormatException
-                    try {viewcount = parseNumber(viewcount_string);} catch (NumberFormatException e) {}
-                    json.put("youtube_viewcount", viewcount);
+                    json.put("youtube_viewcount", viewcount_string);
                     continue;
                 }
                 if ((p = input.indexOf("watch?v=")) >= 0) {
@@ -205,9 +203,14 @@ public class YoutubeScraper {
         return json;
     }
     
-    private static long parseNumber(String n) throws NumberFormatException {
-        String withoutSpaces = CharMatcher.WHITESPACE.removeFrom(n);
-        return Long.parseLong(withoutSpaces);
+    private static String parseValue(String n) {
+        String number_value = CharMatcher.WHITESPACE.removeFrom(n);
+        Pattern number_format = Pattern.compile("^(\\d{1,3})(((,\\d{3})*)|((\\.\\d+)?[MBK]))?$");
+        Matcher m = number_format.matcher(number_value);
+        if (!m.find()) {
+            DAO.severe("This is outputing wrong value. Need to be fixed");
+        }
+        return number_value;
     }
     
     private final static Pattern numberfix = Pattern.compile(",|\\.");


### PR DESCRIPTION
fixes issue #1143

This is patch that considers the fact that a number in youtube can also be alphanumerical like 4.4M (4.4 million) or like a number like 123,123,345. So it considers just as a number