### PR TITLE
Make harvesting decision biased for Kaizen

### DIFF
--- a/src/org/loklak/harvester/strategy/KaizenHarvester.java
+++ b/src/org/loklak/harvester/strategy/KaizenHarvester.java
@@ -215,8 +215,14 @@ public class KaizenHarvester implements Harvester {
 
     @Override
     public int harvest() {
-        if (!queries.isEmpty() && random.nextBoolean())
+        float targetProb = random.nextFloat();
+        float prob = 0.5F;
+        if (QUERIES_LIMIT > 0) {
+            prob = queries.size() / (float)QUERIES_LIMIT;
+        }
+        if (!queries.isEmpty() && targetProb < prob) {
             return harvestMessages();
+        }
 
         grabSuggestions();
 


### PR DESCRIPTION
Solves part of #1156.

A probability is chosen as `queuries.size() / QUERIES_LIMIT`, which is compared to a randomly chosen target probability and decision is taken accordingly. In case of no limit on the queue size, probability to harvest is set to 0.5.

### Short description
I have:
- [x] There is a corresponding issue for this pull request.
- [x] Mentioned the Issue number in the pull request commit message `Fixes #<number> commit message`
- [x] There is only strictly only one commit per issue.

### For the reviewers
I have:
- [ ] Reviewed this pull request by an authorized contributor.
- [ ] The reviewer is assigned to the pull request.
