### PR TITLE
Related to #1112:Add filter for images, videos

### DIFF
--- a/src/org/loklak/api/search/SearchServlet.java
+++ b/src/org/loklak/api/search/SearchServlet.java
@@ -150,6 +150,8 @@ public class SearchServlet extends HttpServlet {
                                     DAO.getConfig(SEARCH_MAX_LOCALHOST_COUNT_NAME, 1000) :
                                     DAO.getConfig(SEARCH_MAX_PUBLIC_COUNT_NAME, 100)));
 
+            String filter = post.get("filter", post.get("filter", ""));
+            
             // create tweet timeline
             final String ordername = post.get("order", Timeline.Order.CREATED_AT.getMessageFieldName());
             final Timeline.Order order = Timeline.parseOrder(ordername);
@@ -186,7 +188,7 @@ public class SearchServlet extends HttpServlet {
                         public void run() {
                             final String scraper_query = tokens.translate4scraper();
                             DAO.log(request.getServletPath() + " scraping with query: " + scraper_query);
-                            Timeline twitterTl = DAO.scrapeTwitter(post, scraper_query, order, timezoneOffsetf, true, timeout, true);
+                            Timeline twitterTl = DAO.scrapeTwitter(post, filter, scraper_query, order, timezoneOffsetf, true, timeout, true);
                             count_twitter_new.set(twitterTl.size());
                             tl.putAll(QueryEntry.applyConstraint(twitterTl, tokens, false)); // pre-localized results are not filtered with location constraint any more
                             tl.setScraperInfo(twitterTl.getScraperInfo());
@@ -263,7 +265,8 @@ public class SearchServlet extends HttpServlet {
                 } else if ("twitter".equals(source) && tokens.raw.length() > 0) {
                     final String scraper_query = tokens.translate4scraper();
                     DAO.log(request.getServletPath() + " scraping with query: " + scraper_query);
-                    Timeline twitterTl = DAO.scrapeTwitter(post, scraper_query, order, timezoneOffset, true, timeout, true);
+                    Timeline twitterTl = DAO.scrapeTwitter(post, filter, scraper_query, order, timezoneOffset, true, timeout, true);
+                            
                     count_twitter_new.set(twitterTl.size());
                     tl.putAll(QueryEntry.applyConstraint(twitterTl, tokens, false)); // pre-localized results are not filtered with location constraint any more
                     tl.setScraperInfo(twitterTl.getScraperInfo());
@@ -321,6 +324,7 @@ public class SearchServlet extends HttpServlet {
                 metadata.put("hits", tl.getHits());                               // number of records in the search index (so far, may be increased later as well)
                 if (tl.getOrder() == Timeline.Order.CREATED_AT) metadata.put("period", tl.period());
                 metadata.put("query", query);
+                metadata.put("filter", filter);
                 metadata.put("client", post.getClientHost());
                 metadata.put("time", System.currentTimeMillis() - post.getAccessTime());
                 metadata.put("servicereduction", post.isDoS_servicereduction() ? "true" : "false");

--- a/src/org/loklak/data/DAO.java
+++ b/src/org/loklak/data/DAO.java
@@ -1099,8 +1099,29 @@ public class DAO {
         return latests.values();
     }
     
-    public static Timeline scrapeTwitter(final Query post, final String q, final Timeline.Order order, final int timezoneOffset, boolean byUserQuery, long timeout, boolean recordQuery) {
+    public static Timeline scrapeTwitter(
+            final Query post,
+            final String q,
+            final Timeline.Order order,
+            final int timezoneOffset,
+            boolean byUserQuery,
+            long timeout,
+            boolean recordQuery) {
+
+        return scrapeTwitter(post, "", q, order, timezoneOffset, byUserQuery, timeout, recordQuery);
+    }
+
+    public static Timeline scrapeTwitter(
+            final Query post,
+            final String filter,
+            final String q,
+            final Timeline.Order order,
+            final int timezoneOffset,
+            boolean byUserQuery,
+            long timeout,
+            boolean recordQuery) {
         // retrieve messages from remote server
+
         ArrayList<String> remote = DAO.getFrontPeers();
         Timeline tl;
         if (remote.size() > 0 && (peerLatency.get(remote.get(0)) == null || peerLatency.get(remote.get(0)).longValue() < 3000)) {
@@ -1111,7 +1132,8 @@ public class DAO {
             if (tl == null || tl.size() == 0) {
                 // maybe the remote server died, we try then ourself
                 start = System.currentTimeMillis();
-                tl = TwitterScraper.search(q, order, true, true, 400);
+
+                tl = TwitterScraper.search(q, filter, order, true, true, 400);
                 if (post != null) post.recordEvent("local_scraper_after_unsuccessful_remote", System.currentTimeMillis() - start);
             } else {
                 tl.writeToIndex();
@@ -1119,7 +1141,8 @@ public class DAO {
         } else {
             if (post != null && remote.size() > 0) post.recordEvent("omitted_scraper_latency_" + remote.get(0), peerLatency.get(remote.get(0)));
             long start = System.currentTimeMillis();
-            tl = TwitterScraper.search(q, order, true, true, 400);
+
+            tl = TwitterScraper.search(q, filter, order, true, true, 400);
             if (post != null) post.recordEvent("local_scraper", System.currentTimeMillis() - start);
         }
 

--- a/test/org/loklak/harvester/TwitterScraperTest.java
+++ b/test/org/loklak/harvester/TwitterScraperTest.java
@@ -17,7 +17,6 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertEquals;
 
-
 import org.loklak.objects.Timeline;
 import org.loklak.harvester.TwitterScraper;
 import org.loklak.objects.MessageEntry;
@@ -30,33 +29,49 @@ import org.loklak.objects.MessageEntry;
 */
 public class TwitterScraperTest {
 
-/*
-    This unit-test tests twitter url creation
-*/
+    /*
+        This unit-test tests twitter url creation
+    */
     @Test
     public void testPrepareSearchURL() {
         String url;
         String[] query = {"fossasia", "from:loklak_test",
-            "spacex since:2017-04-03 until:2017-04-05", };
+                "spacex since:2017-04-03 until:2017-04-05"};
+        String[] filter = {"video", "image", "video,image", "abc,video"};
         String[] out_url = {
             "https://twitter.com/search?f=tweets&vertical=default&q=fossasia&src=typd",
             "https://twitter.com/search?f=tweets&vertical=default&q=from%3Aloklak_test&src=typd",
-            "https://twitter.com/search?f=tweets&vertical=default&q=spacex+since%3A2017-04-03+until%3A2017-04-05&src=typd"};
+            "https://twitter.com/search?f=tweets&vertical=default&q=spacex+since%3A2017-04-03+until%3A2017-04-05&src=typd",
+            "https://twitter.com/search?f=videos&vertical=default&q=fossasia&src=typd",
+            "https://twitter.com/search?f=tweets&vertical=default&q=fossasia&src=typd",
+            "https://twitter.com/search?f=tweets&vertical=default&q=fossasia&src=typd",
+            "https://twitter.com/search?f=tweets&vertical=default&q=fossasia&src=typd",
+        };
 
+        // checking simple urls
         for (int i = 0; i < query.length; i++) {
-            url = TwitterScraper.prepareSearchURL(query[i]);
+            url = TwitterScraper.prepareSearchURL(query[i], "");
 
             //compare urls with urls created
             assertThat(out_url[i], is(url));
         }
+
+        // checking urls having filters
+        for (int i = 0; i < filter.length; i++) {
+            url = TwitterScraper.prepareSearchURL(query[0], filter[i]);
+
+            //compare urls with urls created
+            assertThat(out_url[i+3], is(url));
+        }
+
     }
 
-/*
-    This unit-test tests tweet data fetched from TwitterScraper object.
-    THis test uses TwitterTweet object to get and check tweets
-*/
+    /*
+        This unit-test tests data fetched in TwitterScraper.search() method.
+        This test uses TwitterTweet object to get and check tweets
+    */
     @Test
-    public void testSearch() {
+    public void testSimpleSearch() {
         Timeline ftweet_list;
         Timeline.Order order = Timeline.parseOrder("created_at");
         String https_url = "https://twitter.com/search?f=tweets&vertical=default&q=from%3Aloklak_test&src=typd";
@@ -115,10 +130,8 @@ public class TwitterScraperTest {
 
         String created_date = dateFormatChange(String.valueOf(tweet.getCreatedAt()));
         assertThat(created_date, is(tweet_check.get("created_at")));
-        
-        assertEquals(tweet.getScreenName(), tweet_check.get("screen_name"));
-System.out.println(tweet.getSourceType()+ "   +++++   "+ tweet_check.get("source_type"));
 
+        assertEquals(tweet.getScreenName(), tweet_check.get("screen_name"));
         assertEquals(String.valueOf(tweet.getSourceType()), tweet_check.get("source_type"));
         assertEquals(String.valueOf(tweet.getProviderType()), tweet_check.get("provider_type"));
         assertEquals(tweet.getText(), tweet_check.get("text"));
@@ -128,12 +141,11 @@ System.out.println(tweet.getSourceType()+ "   +++++   "+ tweet_check.get("source
         // Other parameters of twittertweet(used )
         assertThat(tweet.writeToIndex, is(Boolean.parseBoolean(tweet_check.get("writeToIndex"))));
         assertThat(tweet.writeToBackend, is(Boolean.parseBoolean(tweet_check.get("writeToBackend"))));
-
     }
 
-/*
-    This method merges 2 arrays of Timeline Objects(containing array of TwitterTweet objects) into one Timeline object
-*/
+    /*
+        This method merges 2 arrays of Timeline Objects(containing array of TwitterTweet objects) into one Timeline object
+    */
     public Timeline processTweetList(Timeline[] tweet_list) {
 
         for (MessageEntry me: tweet_list[1]) {
@@ -147,9 +159,9 @@ System.out.println(tweet.getSourceType()+ "   +++++   "+ tweet_check.get("source
 
     }
 
-/*
-    Change Date format to compare with other dates
-*/
+    /*
+        Change Date format to compare with other dates
+    */
     public String dateFormatChange(String time) {
 
         String k;


### PR DESCRIPTION
This PR adds feature to :- 
1) searches for tweets with images if we set `filter=image` 
2) for tweets with videos if we set `filter=image`
3) and for both if we set `filter=image,video`

This PR:-

1) Partially fixes issue #1112 , doesn't work for cache(will push when this gets accepted, working on this)
2) outputs the total number of tweets with constraint(image or video) from total count of tweets. As loklak doesn't output more than 100 tweets due to performance issues.

Examples :- 
http://localhost:9000/api/search.json?q=video&filter=video,image&source=twitter
http://localhost:9000/api/search.json?q=paper&filter=image&source=twitter
http://localhost:9000/api/search.json?q=car&filter=video&source=twitter