### PR TITLE
fixes #1177 - Added tests for WordpressCrawlerService.java

### DIFF
--- a/src/org/loklak/api/search/WordpressCrawlerService.java
+++ b/src/org/loklak/api/search/WordpressCrawlerService.java
@@ -84,7 +84,7 @@ public class WordpressCrawlerService extends AbstractAPIHandler implements APIHa
 		Integer iterator = 0;
 
 		try {
-			blogHTML = Jsoup.connect(blogURL).get();
+			blogHTML = Jsoup.connect(blogURL).userAgent("Mozilla").get();
 		} catch (IOException e) {
 			e.printStackTrace();
 		}
@@ -106,7 +106,9 @@ public class WordpressCrawlerService extends AbstractAPIHandler implements APIHa
 
 			articleList_author = article.getElementsByClass("byline");
 			for (Element blogs : articleList_author) {
-				blogPosts[iterator][2] = blogs.text().toString();
+				String author = blogs.text().toString();
+				author = author.substring(author.indexOf(' ') + 1);
+				blogPosts[iterator][2] = author;
 			}
 
 			articleList_content = article.getElementsByClass("entry-content");

--- a/test/org/loklak/api/search/WordpressCrawlerServiceTest.java
+++ b/test/org/loklak/api/search/WordpressCrawlerServiceTest.java
@@ -1,0 +1,34 @@
+package org.loklak.api.search;
+
+import org.junit.Test;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.loklak.api.search.WordpressCrawlerService;
+import org.loklak.susi.SusiThought;
+
+/*
+    These unit-tests test org.loklak.api.search.WordpressCrawlerService
+*/
+public class WordpressCrawlerServiceTest {
+	@Test
+	public void wordpressCrawlerServiceTest() {
+		String url = "http://blog.fossasia.org/author/saptaks/";
+		String author = "saptaks";
+
+		SusiThought response = WordpressCrawlerService.crawlWordpress(url);
+		JSONArray blogs = response.getData();
+
+		for(int i = 0;i < blogs.length(); i++) {
+			JSONObject blog = (JSONObject)blogs.get(i);
+			assertTrue(blog.has("blog_url"));
+			assertTrue(blog.has("title"));
+			assertTrue(blog.has("posted_on"));
+			assertTrue(blog.has("content"));
+			assertTrue(blog.has("author"));
+			assertThat(blog.getString("author"), is(author));
+		}
+	}
+}


### PR DESCRIPTION
fixes issue #1177. Added tests for WordpressCrawlerService.java and
also removed the leading 'Author' from the author field in json
output.

### Short description
I have:
- [x] There is a corresponding issue for this pull request.
- [x] Mentioned the Issue number in the pull request commit message `Fixes #<number> commit message`
- [x] There is only strictly only one commit per issue.

### For the reviewers
I have:
- [ ] Reviewed this pull request by an authorized contributor.
- [ ] The reviewer is assigned to the pull request.
