### PR TITLE
fixes #1169 - Added test for Github profile scraper

### DIFF
--- a/test/org/loklak/TestRunner.java
+++ b/test/org/loklak/TestRunner.java
@@ -4,6 +4,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.loklak.harvester.TwitterScraperTest;
 import org.loklak.harvester.YoutubeScraperTest;
+import org.loklak.api.search.GithubProfileScraperTest;
 
 /*
     TestRunner for harvesters
@@ -11,7 +12,8 @@ import org.loklak.harvester.YoutubeScraperTest;
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
     TwitterScraperTest.class,
-        YoutubeScraperTest.class
+    YoutubeScraperTest.class,
+    GithubProfileScraperTest.class
 })
 public class TestRunner {
 }

--- a/test/org/loklak/api/search/GithubProfileScraperTest.java
+++ b/test/org/loklak/api/search/GithubProfileScraperTest.java
@@ -1,0 +1,45 @@
+package org.loklak.api.search;
+
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import org.json.JSONObject;
+import org.loklak.api.search.GithubProfileScraper;
+import org.loklak.susi.SusiThought;
+
+public class GithubProfileScraperTest {
+	@Test
+	public void githubProfileScraperOrgTest() {
+		String profile = "fossasia";
+		String shortDescription = "Open Technologies in Asia";
+		String userName = "fossasia";
+		String userId = "6295529";
+		String location = "Singapore";
+		String specialLink = "http://fossasia.org";
+
+		SusiThought response = GithubProfileScraper.scrapeGithub(profile);
+		JSONObject fetchedProfile = (JSONObject)response.getData().get(0);
+
+		assertEquals(fetchedProfile.getString("short_description"), shortDescription);
+		assertEquals(fetchedProfile.getString("user_name"), userName);
+		assertEquals(fetchedProfile.getString("user_id"), userId);
+		assertEquals(fetchedProfile.getString("location"), location);
+		assertEquals(fetchedProfile.getString("special_link"), specialLink);
+	}
+
+	@Test
+	public void githubProfileScraperUserTest() {
+		String profile = "djmgit";
+		String userName = "djmgit";
+		String fullName = "Deepjyoti Mondal";
+		String specialLink = "http://djmgit.github.io";
+		String userId = "16368427";
+
+		SusiThought response = GithubProfileScraper.scrapeGithub(profile);
+		JSONObject fetchedProfile = (JSONObject)response.getData().get(0);
+
+		assertEquals(fetchedProfile.getString("user_name"), userName);
+		assertEquals(fetchedProfile.getString("full_name"), fullName);
+		assertEquals(fetchedProfile.getString("special_link"), specialLink);
+		assertEquals(fetchedProfile.getString("user_id"), userId);
+	}
+}


### PR DESCRIPTION
fixes issue #1169, Added tests for GithubProfileScraper service
I have:
- [x] There is a corresponding issue for this pull request.
- [x] Mentioned the Issue number in the pull request commit message `Fixes #<number> commit message`
- [x] There is only strictly only one commit per issue.

### For the reviewers
I have:
- [ ] Reviewed this pull request by an authorized contributor.
- [ ] The reviewer is assigned to the pull request.
