### PR TITLE
Fixes #1112: Add image, video filter constraints for cache

### DIFF
--- a/test/org/loklak/harvester/TwitterScraperTest.java
+++ b/test/org/loklak/harvester/TwitterScraperTest.java
@@ -6,6 +6,8 @@ import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.time.ZonedDateTime;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
@@ -33,11 +35,18 @@ public class TwitterScraperTest {
         This unit-test tests twitter url creation
     */
     @Test
-    public void testPrepareSearchURL() {
+    public void testPrepareSearchUrl() {
         String url;
         String[] query = {"fossasia", "from:loklak_test",
                 "spacex since:2017-04-03 until:2017-04-05"};
-        String[] filter = {"video", "image", "video,image", "abc,video"};
+        ArrayList<String>[] filterList = (ArrayList<String>[])new ArrayList[3];
+        for (int i = 0; i < filterList.length; i++) {
+            filterList[i] = new ArrayList<String>();
+        }
+        filterList[0].add("video");
+        filterList[1].addAll(Arrays.asList("image", "video"));
+        filterList[2].addAll(Arrays.asList("abc", "video"));
+
         String[] out_url = {
             "https://twitter.com/search?f=tweets&vertical=default&q=fossasia&src=typd",
             "https://twitter.com/search?f=tweets&vertical=default&q=from%3Aloklak_test&src=typd",
@@ -45,13 +54,12 @@ public class TwitterScraperTest {
             "https://twitter.com/search?f=videos&vertical=default&q=fossasia&src=typd",
             "https://twitter.com/search?f=tweets&vertical=default&q=fossasia&src=typd",
             "https://twitter.com/search?f=tweets&vertical=default&q=fossasia&src=typd",
-            "https://twitter.com/search?f=tweets&vertical=default&q=fossasia&src=typd",
         };
 
         // checking simple urls
         for (int i = 0; i < query.length; i++) {
             try {
-                url = (String)executePrivateMethod(TwitterScraper.class, "prepareSearchURL",new Class[]{String.class, String.class}, query[i], "");
+                url = (String)executePrivateMethod(TwitterScraper.class, "prepareSearchUrl",new Class[]{String.class, String.class}, query[i], "");
 
                 //compare urls with urls created
                 assertThat(out_url[i], is(url));
@@ -61,9 +69,9 @@ public class TwitterScraperTest {
         }
 
         // checking urls having filters
-        for (int i = 0; i < filter.length; i++) {
+        for (int i = 0; i < filterList.length; i++) {
             try {
-                url = (String)executePrivateMethod(TwitterScraper.class, "prepareSearchURL",new Class[]{String.class, String.class}, query[0], filter[i]);
+                url = (String)executePrivateMethod(TwitterScraper.class, "prepareSearchUrl",new Class[]{String.class, String.class}, query[0], filterList[i]);
                 //compare urls with urls created
                 assertThat(out_url[i+3], is(url));
             } catch(Exception e) {


### PR DESCRIPTION
### Short description

This PR:-
1) Solves issue #1112.
2) Sync with PR #1164 , to use same ArrayList variable for filter
3) Add filter for get filtered tweets with images , videos or both.

Some tweets with videos doesn't output video links, but has video in that tweet. Issue for this bug has been created as Issue #1171 .

###Examples :-

1) http://localhost:9000/api/search.json?q=video&filter=video,image&source=twitter
2) http://localhost:9000/api/search.json?q=paper&filter=image&source=twitter
3) http://localhost:9000/api/search.json?q=car&filter=video&source=twitter
4) http://localhost:9000/api/search.json?q=video&filter=video,image&source=cache
5) http://localhost:9000/api/search.json?q=paper&filter=image&source=cache
6) http://localhost:9000/api/search.json?q=car&filter=video&source=cache
7) http://localhost:9000/api/search.json?q=video&filter=video,image
8) http://localhost:9000/api/search.json?q=paper&filter=image
9) http://localhost:9000/api/search.json?q=car&filter=video

I have:
- [x] There is a corresponding issue for this pull request.
- [x] Mentioned the Issue number in the pull request commit message `Fixes #<number> commit message`
- [x] There is only strictly only one commit per issue.

### For the reviewers
I have:
- [ ] Reviewed this pull request by an authorized contributor.
- [ ] The reviewer is assigned to the pull request.
