### PR TITLE
Use unbescape to unescape HTML in html2utf8 and improve whitespace cleaning

### DIFF
--- a/src/org/loklak/objects/MessageEntry.java
+++ b/src/org/loklak/objects/MessageEntry.java
@@ -42,6 +42,8 @@ import org.loklak.geo.LocationSource;
 import org.loklak.objects.QueryEntry.PlaceContext;
 import org.loklak.tools.bayes.Classification;
 
+import org.unbescape.html.HtmlEscape;
+
 public class MessageEntry extends AbstractObjectEntry implements ObjectEntry {
 
     public static final String RICH_TEXT_SEPARATOR = "\n***\n";
@@ -640,8 +642,16 @@ public class MessageEntry extends AbstractObjectEntry implements ObjectEntry {
         if (user != null) m.put("user", user.toJSON());
         return m;
     }
-    
+
     public static String html2utf8(String s) {
+        String unescape = HtmlEscape.unescapeHtml(s);
+        unescape = A_END_TAG.matcher(unescape).replaceAll("");
+        unescape = unescape.trim().replaceAll(" +", " ");
+        return unescape;
+    }
+
+    public static String html2utf8Custom(String str) {
+        String s = str;
         int p, q;
         // hex coding &#
         try {
@@ -678,7 +688,7 @@ public class MessageEntry extends AbstractObjectEntry implements ObjectEntry {
             else clean.append(c);
         }
         // remove double spaces
-        return clean.toString().replaceAll("  ", " ");
+        return clean.toString().trim().replaceAll(" +", " ");
     }
 
     private final static Pattern A_END_TAG = Pattern.compile("</a>");


### PR DESCRIPTION
### Short description

Fixes #1188.

HTML unescape method is wrapped as new `html2utf8` with the removal of extra whitespace and `</a>` tag. Whitespace cleansing is fixed (`( )+` -> ` `).

No more `NumberFormatException` as `org.unbescape.html.HtmlEscape#unescapeHtml` handles cleaning of `UTF8`.

I have checked for consistency of results by comparing the output of the two methods.

I have:
- [x] There is a corresponding issue for this pull request.
- [x] Mentioned the Issue number in the pull request commit message `Fixes #<number> commit message`
- [x] There is only strictly only one commit per issue.

### For the reviewers
I have:
- [ ] Reviewed this pull request by an authorized contributor.
- [ ] The reviewer is assigned to the pull request.
