### PR TITLE
Fixes #1202: Modify loggers in Loklak Server for testing

### DIFF
--- a/conf/config.properties
+++ b/conf/config.properties
@@ -255,6 +255,10 @@ classification.language.spanish=que,de,no,a,la,el,es,y,en,lo,un,por,qué,me,una,t
 classification.language.dutch=de,van,een,het,en,in,is,dat,op,te,De,zijn,voor,met,die,niet,aan,er,om,Het,ook,als,dan,maar,bij,of,uit,nog,worden,door,naar,heeft,tot,ze,wordt,over,hij,In,meer,jaar,was,ik,kan,je,zich,al,hebben,geen,hun,we,wat,Een,Maar,werd,moet,wel,kunnen,Dat,nu,dit,deze,zal,Ik,veel,zo,En,andere,nieuwe,zou,twee,moeten,onder,eerste,haar,Van,wil,tegen,men,mensen,gaat,tussen,grote,waar,goed,maken,dus,alleen,Hij,Op,frank,ons,u,daar,na,had,gaan,alle,Als,Er,één
 
 # flags
+flag.log.dao = true;
+flag.severe.dao = true;
+flag.debug.dao = true;
+flag.trace.dao = true;
 flag.fixunshorten = false
 flag.replaceinsteadunshorten = false
 flag.debug.twitter_scraper = false

--- a/src/org/loklak/data/DAO.java
+++ b/src/org/loklak/data/DAO.java
@@ -1317,29 +1317,48 @@ public class DAO {
      * For logging informational events
      */
     public static void log(String line) {
-        Log.getLog().info(line);
+        if(DAO.getConfig("flag.log.dao", "true").equals("true")) {
+            Log.getLog().info(line);
+        }
     }
 
     /**
      * For events serious enough to inform and log, but not fatal.
      */
     public static void severe(String line) {
-        Log.getLog().warn(line);
+        if(DAO.getConfig("flag.severe.dao", "true").equals("true")) {
+            Log.getLog().warn(line);
+        }
     }
 
     public static void severe(String line, Throwable e) {
-        Log.getLog().warn(line, e);
+        if(DAO.getConfig("flag.severe.dao", "true").equals("true")) {
+            Log.getLog().warn(line, e);
+        }
     }
     
     public static void severe(Throwable e) {
-        Log.getLog().warn(e);
+        if(DAO.getConfig("flag.severe.dao", "true").equals("true")) {
+            Log.getLog().warn(e);
+        }
     }
 
     /**
      * For Debugging events (very noisy).
      */
     public static void debug(Throwable e) {
-        Log.getLog().debug(e);
+        if(DAO.getConfig("flag.debug.dao", "true").equals("true")) {
+            Log.getLog().debug(e);
+        }
+    }
+
+    /**
+     * For Stacktracing exceptions (preferred over debug).
+     */
+    public static void trace(Throwable e) {
+        if(DAO.getConfig("flag.trace.dao", "true").equals("true")) {
+            e.printStackTrace();
+        }
     }
 
 }


### PR DESCRIPTION
Fix issue #1202
This PR adds flags to customize loggers during development
This PR adds `trace(throwable e)` logger to use it in place of `severe(throwable e)` to get complete traceback instead of some starting lines of stacktrace. 
I have:
- [x] There is a corresponding issue for this pull request.
- [x] Mentioned the Issue number in the pull request commit message `Fixes #<number> commit message`
- [x] There is only strictly only one commit per issue.

### For the reviewers
I have:
- [ ] Reviewed this pull request by an authorized contributor.
- [ ] The reviewer is assigned to the pull request.
