### PR TITLE
Fix 1216: Revert "Installation and Start on a user specified port"

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,14 +49,8 @@ This command may give an error while building like `Unable to locate tools.jar`.
 It means that there is no java in your system or JAVA_HOME Environment Variable is not set. [Refererence](https://www.digitalocean.com/community/tutorials/how-to-install-java-on-ubuntu-with-apt-get) to fix it and run `ant` again.
 
     > bin/start.sh
-    > bin/start.sh -p 8888 # Port to start Loklak
-After all server processes are running, loklak tries to open a browser page itself. If that does 
-not happen, just open http://localhost:9000 (if you have used a different port use that in place of 9000); if you made the installation on a headless or remote server, then replace 'localhost' with your server name.
 
-Similarly installation of loklak can be done.
-
-    > bin/installation.sh
-    > bin/installation.sh -p 8888
+After all server processes are running, loklak tries to open a browser page itself. If that does not happen, just open http://localhost:9000; if you made the installation on a headless or remote server, then replace 'localhost' with your server name.
 
 To stop loklak, run: (this will block until the server has actually terminated)
 
@@ -93,7 +87,7 @@ To install loklak on Eclipse, please refer to the [loklak Eclipse readme](/docs/
 
 - build loklak (you need to do this only once, see above)
 - run `bin/start.sh`
-- open `http://localhost:9000` in your browser (use port number **loklak** is running on)
+- open `http://localhost:9000` in your browser
 - to shut down loklak, run `bin/stop.sh`
 
 ## How do I analyze data acquired by loklak

--- a/bin/installation.sh
+++ b/bin/installation.sh
@@ -7,31 +7,18 @@ cd $(dirname $0)/..
 
 # Execute preload script
 source bin/.preload.sh
-source bin/utility.sh
 
 echo "starting loklak installation"
 echo "startup" > $STARTUPFILE
 
-while getopts ":p:" opt; do
-    case $opt in
-        p)
-            PORT_NUMBER=$OPTARG
-            ;;
-        \?)
-            echo -e " -p\tPort to start LoklakServer on"
-            exit 1
-            ;;
-    esac
-done
-
-cmdline="$cmdline -server -classpath $CLASSPATH -Dlog4j.configurationFile=$LOGCONFIG org.loklak.LoklakInstallation $PORT_NUMBER >> data/loklak.log 2>&1 &";
+cmdline="$cmdline -server -classpath $CLASSPATH -Dlog4j.configurationFile=$LOGCONFIG org.loklak.LoklakInstallation >> data/loklak.log 2>&1 &";
 
 eval $cmdline
 PID=$!
 echo $PID > $PIDFILE
 
 while [ -f $STARTUPFILE ] && [ $(ps -p $PID -o pid=) ]; do
-	if [ $(cat "$STARTUPFILE") = 'done' ]; then
+	if [ $(cat $STARTUPFILE) = 'done' ]; then
 		break
 	else
 		sleep 1
@@ -39,12 +26,7 @@ while [ -f $STARTUPFILE ] && [ $(ps -p $PID -o pid=) ]; do
 done
 
 if [ -f $STARTUPFILE ] && [ $(ps -p $PID -o pid=) ]; then
-    if [ "$PORT_NUMBER" ]; then
-        CUSTOMPORT=$PORT_NUMBER
-    else
-	    CUSTOMPORT=$(grep -iw 'port.http' conf/config.properties | sed 's/^[^=]*=//' );
-	fi
-	change_shortlink_urlstub $CUSTOMPORT # function defined in utility.sh
+	CUSTOMPORT=$(grep -iw 'port.http' conf/config.properties | sed 's/^[^=]*=//' );
 	LOCALHOST=$(grep -iw 'shortlink.urlstub' conf/config.properties | sed 's/^[^=]*=//');
 	echo "loklak installation started at port $CUSTOMPORT, open your browser at $LOCALHOST"
 	rm -f $STARTUPFILE

--- a/src/org/loklak/LoklakInstallation.java
+++ b/src/org/loklak/LoklakInstallation.java
@@ -129,10 +129,7 @@ public class LoklakInstallation {
         if(env.containsKey("PORTSSL")) {
             httpsPort = Integer.parseInt(env.get("PORTSSL"));
         }
-
-        if (args.length > 0) {
-            httpPort = Integer.valueOf(args[0]);
-        }
+        
         // check if a loklak service is already running on configured port
         try{
         	checkServerPorts(httpPort, httpsPort);

--- a/src/org/loklak/LoklakServer.java
+++ b/src/org/loklak/LoklakServer.java
@@ -262,11 +262,7 @@ public class LoklakServer {
         if(env.containsKey("PORTSSL")) {
             httpsPort = Integer.parseInt(env.get("PORTSSL"));
         }
-
-        if (args.length > 0) {
-            httpPort = Integer.parseInt(args[0]);
-        }
-
+        
         // check if a loklak service is already running on configured port
         try{
         	checkServerPorts(httpPort, httpsPort);


### PR DESCRIPTION
### Short description

Fixes #1216.
Related #1159.

Kubernetes deployment: http://104.198.183.77/

This reverts commit 1e0bcd5b353f9f54e65e49979c04e5998f6a3d38.

Conflicts (resolved):
	bin/installation.sh
	bin/start.sh

I have:
- [x] There is a corresponding issue for this pull request.
- [x] Mentioned the Issue number in the pull request commit message `Fixes #<number> commit message`
- [x] There is only strictly only one commit per issue.

### For the reviewers
I have:
- [ ] Reviewed this pull request by an authorized contributor.
- [ ] The reviewer is assigned to the pull request.
