### PR TITLE
Reduce heap size for Elastisearch

### DIFF
--- a/bin/heroku_start.sh
+++ b/bin/heroku_start.sh
@@ -3,4 +3,7 @@
 # Make sure we're on project root
 cd $(dirname $0)/..
 
+# Reduce Elasticsearch heap size
+export ES_HEAP_SIZE=100m
+
 exec ./bin/start.sh -Idn


### PR DESCRIPTION
### Short description

Fixes #1225.

The max allowable RAM usage for single heroku dyno is 512 MB (for free one) and the app is killed upon exceeding 200% usage (including swap). So, reducing the max allowable memory will stop the app from crashing.

This PR sets the environment variable `ES_HEAP_SIZE` to 100m so that it doesn't utilise a lot of memory.

I have:
- [x] There is a corresponding issue for this pull request.
- [x] Mentioned the Issue number in the pull request commit message `Fixes #<number> commit message`
- [x] There is only strictly only one commit per issue.

### For the reviewers
I have:
- [ ] Reviewed this pull request by an authorized contributor.
- [ ] The reviewer is assigned to the pull request.
