### PR TITLE
Add support for aggregation by country

### DIFF
--- a/src/org/loklak/data/ElasticsearchClient.java
+++ b/src/org/loklak/data/ElasticsearchClient.java
@@ -956,7 +956,7 @@ public class ElasticsearchClient {
      * @param classes Classes to consider
      * @return HashMap with required aggregations
      */
-    public HashMap<String, HashMap<String, Double>> classifierScore(String index, String classifierName, List<String> classes) {
+    public final HashMap<String, HashMap<String, Double>> classifierScore(String index, String classifierName, List<String> classes) {
         SearchResponse response = getAggregationResponse(index, getClassifierAggregationBuilder(classifierName));
         Terms aggrs = response.getAggregations().get("by_class");
         return getAggregationByClass(aggrs, classes);
@@ -971,7 +971,7 @@ public class ElasticsearchClient {
      * @param endDate End date for creation of row
      * @return HashMap with required aggregations
      */
-    public HashMap<String, HashMap<String, Double>> classifierScore(
+    public final HashMap<String, HashMap<String, Double>> classifierScore(
         String index, String classifierName, List<String> classes, String startDate, String endDate) {
         if (startDate == null && endDate == null) {
             return classifierScore(index, classifierName, classes);
@@ -990,7 +990,7 @@ public class ElasticsearchClient {
      * @param endDate End date for creation of row
      * @return HashMap with required aggregations
      */
-    public HashMap<String, HashMap<String, HashMap<String,Double>>> classifierScoreForCountry(
+    public final HashMap<String, HashMap<String, HashMap<String,Double>>> classifierScoreForCountry(
         String index, String classifierName, List<String> classes, String startDate, String endDate) {
         // No time restrictions
         if (startDate == null && endDate == null) {
@@ -998,7 +998,7 @@ public class ElasticsearchClient {
         }
         SearchResponse response = getAggregationResponse(index, getClassifierAggregationBuilderByCountry(
             "place_country_code", classifierName, startDate, endDate));
-        Range aggr = response.getAggregations().get("by_time");
+        Range aggr = response.getAggregations().get("by_date");
         HashMap<String, HashMap<String, HashMap<String,Double>>> retMap = getAggregationByTimeWithCountries(aggr, classes);
         // Put global aggregation
         retMap.put("GLOBAL", classifierScore(index, classifierName, classes, startDate, endDate));
@@ -1015,7 +1015,7 @@ public class ElasticsearchClient {
      * @param countries Country codes to consider
      * @return HashMap with required aggregations
      */
-    public HashMap<String, HashMap<String, HashMap<String,Double>>> classifierScoreForCountry(
+    public final HashMap<String, HashMap<String, HashMap<String,Double>>> classifierScoreForCountry(
         String index, String classifierName, List<String> classes, String startDate, String endDate, List<String> countries) {
         if (startDate == null && endDate == null) {
             return classifierScoreForCountry(index, classifierName, classes, countries);
@@ -1028,7 +1028,7 @@ public class ElasticsearchClient {
             }
             retMap.put(key, copy.get(key));
         }
-        return copy;
+        return retMap;
     }
 
     /**
@@ -1038,7 +1038,7 @@ public class ElasticsearchClient {
      * @param classes Classes to consider
      * @return HashMap with required aggregations
      */
-    public HashMap<String, HashMap<String, HashMap<String,Double>>> classifierScoreForCountry(String index, String classifierName, List<String> classes) {
+    public final HashMap<String, HashMap<String, HashMap<String,Double>>> classifierScoreForCountry(String index, String classifierName, List<String> classes) {
         SearchResponse response = getAggregationResponse(index, getClassifierAggregationBuilderByCountry("place_country_code", classifierName));
         Terms aggr = response.getAggregations().get("by_country");
         HashMap<String, HashMap<String, HashMap<String,Double>>> retMap = getAggregationByCountry(aggr, classes);
@@ -1055,7 +1055,7 @@ public class ElasticsearchClient {
      * @param countries Countiries to consider
      * @return HashMap with required aggregations
      */
-    public HashMap<String, HashMap<String, HashMap<String,Double>>> classifierScoreForCountry(
+    public final HashMap<String, HashMap<String, HashMap<String,Double>>> classifierScoreForCountry(
         String index, String classifierName, List<String> classes, List<String> countries) {
         HashMap<String, HashMap<String, HashMap<String,Double>>> retMap = new HashMap<>();
 


### PR DESCRIPTION
### Short Description

Fixes #1286.

This PR adds support for performing aggregations by country.

* User can get data for countries by using `countries` parameter.
* Country code will be in 2 digits case-insensitive format.
* Results would contain global aggregations under `GLOBAL` key of response `JSON`.
* Users can pass `all` (case insensitive) as `countries` to get data for all available countries.

Deployment - http://104.154.169.159

Examples - 
* http://104.154.169.159/api/classifier.json?classifier=language&all=true
* http://104.154.169.159/api/classifier.json?classifier=language&all=true&countries=in,us
* http://104.154.169.159/api/classifier.json?classifier=emotion&all=true&countries=all
* http://104.154.169.159/api/classifier.json?classifier=emotion&classes=anger,joy
* http://104.154.169.159/api/classifier.json?classifier=emotion&classes=anger,joy&since=2017-07

#### TODO
- [x] Wait for #1283.
- [x] Update code with `development`.
- [x] Fix access specifiers in `ElasricsearchClient.java`.
- [x] Deployment link with examples.

I have:
- [x] There is a corresponding issue for this pull request.
- [x] Mentioned the Issue number in the pull request commit message `Fixes #<number> commit message`
- [x] There is only strictly only one commit per issue.

### For the reviewers
I have:
- [ ] Reviewed this pull request by an authorized contributor.
- [ ] The reviewer is assigned to the pull request.
