### PR TITLE
Unshorten URL until applicable

### DIFF
--- a/src/org/loklak/harvester/RedirectUnshortener.java
+++ b/src/org/loklak/harvester/RedirectUnshortener.java
@@ -6,12 +6,12 @@
  *  modify it under the terms of the GNU Lesser General Public
  *  License as published by the Free Software Foundation; either
  *  version 2.1 of the License, or (at your option) any later version.
- *  
+ *
  *  This library is distributed in the hope that it will be useful,
  *  but WITHOUT ANY WARRANTY; without even the implied warranty of
  *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  *  Lesser General Public License for more details.
- *  
+ *
  *  You should have received a copy of the GNU Lesser General Public License
  *  along with this program in the file lgpl21.txt
  *  If not, see <http://www.gnu.org/licenses/>.
@@ -57,7 +57,7 @@ public class RedirectUnshortener {
         "flip.it",
         "lnkd.in"
     };
-    
+
     private final static String[] untestedHosts = new String[] {
         "is.gd",
         "ta.gd",
@@ -72,15 +72,12 @@ public class RedirectUnshortener {
         "igg.me",
         "twiza.ru"
     };
-    
+
     public static String unShorten(String urlstring) {
         //long start = System.currentTimeMillis();
-        if (!isApplicable(urlstring)) {
-            return urlstring;
-        }
         try {
             int termination = 10; // loop for recursively shortened urls
-            while (termination-- > 0) {
+            while (termination-- > 0 && isApplicable(urlstring)) {
                 String unshortened = ClientConnection.getRedirect(urlstring);
                 if (unshortened.equals(urlstring)) {
                     return urlstring;
@@ -94,7 +91,7 @@ public class RedirectUnshortener {
             return urlstring;
         }
     }
-    
+
     private static boolean isApplicable(String urlstring) {
         String s = urlstring.toLowerCase();
         if (!s.startsWith("http://") && !s.startsWith("https://")) return false;
@@ -113,7 +110,7 @@ public class RedirectUnshortener {
         }
         return false;
     }
-    
+
     /**
      * this is the raw implementation if ClientConnection.getRedirect.
      * Surprisingly it's much slower, but some redirects cannot be discovered with the other
@@ -158,7 +155,7 @@ public class RedirectUnshortener {
         socket.close();
         return urlstring;
     }
-    
+
     public static void main(String[] args) {
         String[] test = new String[] {
                 "http://tmblr.co/Z6YPNx1jL1hHK",
@@ -193,11 +190,11 @@ public class RedirectUnshortener {
             }
         }
     }
-    
+
     /**
      * does not work:
      * https://tr.im/v31Rf
      * http://dlvr.it/8htd6W  // works on terminal but not here
      */
-    
+
 }

--- a/test/org/loklak/harvester/RedirectUnshortenerTest.java
+++ b/test/org/loklak/harvester/RedirectUnshortenerTest.java
@@ -21,7 +21,7 @@ public class RedirectUnshortenerTest {
         shortlinkMap.put("http://ow.ly/P9SX30ddSTI", "https://github.com/loklak/loklak_server/issues/1284");
         shortlinkMap.put("http://bit.do/blog-fossasia", "http://blog.fossasia.org/");
         shortlinkMap.put("http://fb.me/4lcXZsyyO", "https://www.facebook.com/permalink.php?story_fbid=1550262581900846&id=1381813572079082");
-        shortlinkMap.put("http://wp.me/sf2B5-shorten", "https://en.blog.wordpress.com/2009/08/14/shorten/");
+        shortlinkMap.put("http://wp.me/sf2B5-shorten", "http://en.blog.wordpress.com/2009/08/14/shorten/");
         shortlinkMap.put("https://is.gd/gyk3VT", "https://github.com/fossasia/");
         shortlinkMap.put("https://is.gd/Lros16", "https://twitter.com/lklknt");
 

--- a/test/org/loklak/http/ClientConnectionTest.java
+++ b/test/org/loklak/http/ClientConnectionTest.java
@@ -1,0 +1,22 @@
+package org.loklak.http;
+
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+import java.util.HashMap;
+
+public class ClientConnectionTest {
+
+    @Test
+    public void metaUrlExtractorTest() throws IOException {
+        HashMap<String, String> linkMap = new HashMap<>();
+
+        linkMap.put("http://yacy.net", "http://yacy.net/en/index.html");
+
+        for (HashMap.Entry<String, String> pair : linkMap.entrySet()) {
+            assertEquals(pair.getValue(), ClientConnection.getRedirect(pair.getKey()));
+        }
+    }
+
+}


### PR DESCRIPTION
### Short description

Fixes #1297.

URL redirect unshortener would not keep unshortening URLs until it has reached some final URL. It will do so only until there are chances of URL being trackable.

I have:
- [x] There is a corresponding issue for this pull request.
- [x] Mentioned the Issue number in the pull request commit message `Fixes #<number> commit message`
- [x] There is only strictly only one commit per issue.

### For the reviewers
I have:
- [x] Reviewed this pull request by an authorized contributor.
- [x] The reviewer is assigned to the pull request.
