### PR TITLE
Add comparator for ScoreWrapper class and tests

### DIFF
--- a/src/org/loklak/harvester/strategy/PriorityKaizenHarvester.java
+++ b/src/org/loklak/harvester/strategy/PriorityKaizenHarvester.java
@@ -8,9 +8,9 @@ import java.util.Queue;
 
 public class PriorityKaizenHarvester extends KaizenHarvester {
 
-    private static class PriorityKaizenQueries extends KaizenQueries {
+    public static class PriorityKaizenQueries extends KaizenQueries {
 
-        private Comparator<ScoreWrapper> scoreComparator = (scoreWrapper, t1) -> (int) (scoreWrapper.score - t1.score);
+        private Comparator<ScoreWrapper> scoreComparator = (scoreWrapper, t1) -> (int) (1000 * (t1.score - scoreWrapper.score));
 
         private Queue<ScoreWrapper> queue;
         private int maxSize;
@@ -25,6 +25,10 @@ public class PriorityKaizenHarvester extends KaizenHarvester {
                 this.score = score;
             }
 
+            @Override
+            public boolean equals(Object obj) {
+                return obj instanceof ScoreWrapper && this.query.equals(((ScoreWrapper)obj).query);
+            }
         }
 
         public PriorityKaizenQueries(int size) {

--- a/test/org/loklak/harvester/strategy/PriorityKaizenHarvesterTest.java
+++ b/test/org/loklak/harvester/strategy/PriorityKaizenHarvesterTest.java
@@ -1,0 +1,36 @@
+package org.loklak.harvester.strategy;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+import org.loklak.harvester.strategy.PriorityKaizenHarvester.PriorityKaizenQueries;
+
+public class PriorityKaizenHarvesterTest {
+
+    @Test
+    public void testPriority() {
+        PriorityKaizenQueries queries = new PriorityKaizenQueries(2);
+        queries.addQuery("abc", 0.5);
+        queries.addQuery("ghi", 0.8);
+        queries.addQuery("def", 0.6);
+        assertEquals("ghi", queries.getQuery());
+        assertEquals("def", queries.getQuery());
+        assertEquals("abc", queries.getQuery());
+        assertEquals(0, queries.getSize());
+    }
+
+    @Test
+    public void testDuplicate() {
+        PriorityKaizenQueries queries = new PriorityKaizenQueries(2);
+        queries.addQuery("abc", 0.5);
+        queries.addQuery("abc", 0.6);
+        assertEquals(1, queries.getSize());
+    }
+
+    @Test
+    public void testMaxSize() {
+        PriorityKaizenQueries queries = new PriorityKaizenQueries(10);
+        assertEquals(10, queries.getMaxSize());
+    }
+
+}


### PR DESCRIPTION
Also fix precision issue with comparator

### Short description
Fixes #1308.

* Added comparator for `ScoreWrapper` objects.
* Fixed precision for comparison with the priority queue.
* Added tests.

I have:
- [x] There is a corresponding issue for this pull request.
- [x] Mentioned the Issue number in the pull request commit message `Fixes #<number> commit message`
- [x] There is only strictly only one commit per issue.

### For the reviewers
I have:
- [ ] Reviewed this pull request by an authorized contributor.
- [ ] The reviewer is assigned to the pull request.
