### PR TITLE
Fixes #1321: Removes pic.twitter.com/imageId links from tweet text

### DIFF
--- a/src/org/loklak/harvester/TwitterScraper.java
+++ b/src/org/loklak/harvester/TwitterScraper.java
@@ -720,7 +720,7 @@ public class TwitterScraper {
         }
 
         public boolean willBeTimeConsuming() {
-            return timeline_link_pattern.matcher(this.text).find() || timeline_embed_pattern.matcher(this.text).find();
+            return timeline_link_pattern.matcher(this.text).find();
         }
 
         @Override
@@ -810,8 +810,7 @@ public class TwitterScraper {
             try {
                 Matcher m = timeline_embed_pattern.matcher(text);
                 if (m.find()) {
-                    String shorturl = RedirectUnshortener.unShorten(m.group(2));
-                    text = m.replaceFirst(" https://pic.twitter.com/" + shorturl + " ");
+                    text = m.replaceFirst("");
                     continue;
                 }
             } catch (Throwable e) {

--- a/test/org/loklak/harvester/TwitterScraperTest.java
+++ b/test/org/loklak/harvester/TwitterScraperTest.java
@@ -104,7 +104,7 @@ public class TwitterScraperTest {
         tweet_check.put("status_id_url", "https://twitter.com/loklak_test/status/870536303569289216");
         tweet_check.put("place_name", "");
         tweet_check.put("place_id", "");
-        tweet_check.put("text", "Tweet with a video https://pic.twitter.com/1R9ICL6icm");
+        tweet_check.put("text", "Tweet with a video");
         tweet_check.put("writeToIndex", "true");
         tweet_check.put("writeToBackend", "true");
 


### PR DESCRIPTION
### Short description

Fixes #1321.
- Removes `pic.twitter.com/ImageId` links from tweet text

I have:
- [x] There is a corresponding issue for this pull request.
- [x] Mentioned the Issue number in the pull request commit message `Fixes #<number> commit message`
- [x] There is only strictly only one commit per issue.

### For the reviewers
I have:
- [ ] Reviewed this pull request by an authorized contributor.
- [ ] The reviewer is assigned to the pull request.
