### PR TITLE
Add config to disable dump generation

### DIFF
--- a/conf/config.properties
+++ b/conf/config.properties
@@ -294,3 +294,6 @@ caretaker.backendpush.backoff = 3000
 
 # Classifier servlet caching expiry time in milliseconds
 classifierservlet.cache.timeout = 300000
+
+# Enable dump generator
+dump.write_enabled = true

--- a/src/org/loklak/api/cms/DumpDownloadServlet.java
+++ b/src/org/loklak/api/cms/DumpDownloadServlet.java
@@ -53,6 +53,9 @@ public class DumpDownloadServlet extends HttpServlet {
     @Override
     protected void doGet(HttpServletRequest request,
         HttpServletResponse response) throws ServletException, IOException {
+        if (!DAO.writeDump) {
+            response.sendError(HttpServletResponse.SC_FORBIDDEN, "Dump generation is disabled on this peer");
+        }
         final Query post = RemoteAccess.evaluate(request);
         String path = request.getPathInfo();
         final long now = System.currentTimeMillis();

--- a/src/org/loklak/data/DAO.java
+++ b/src/org/loklak/data/DAO.java
@@ -121,6 +121,8 @@ public class DAO {
     public final static String FOLLOWING_DUMP_FILE_PREFIX = "following_";
     private static final String IMPORT_PROFILE_FILE_PREFIX = "profile_";
 
+    public static boolean writeDump;
+
     public final static int CACHE_MAXSIZE =   10000;
     public final static int EXIST_MAXSIZE = 4000000;
 
@@ -188,6 +190,8 @@ public class DAO {
         conf_dir = new File("conf");
         bin_dir = new File("bin");
         html_dir = new File("html");
+
+        writeDump = DAO.getConfig("dump.write_enabled", true);
 
         // initialize public and private keys
 		public_settings = new Settings(new File("data/settings/public.settings.json"));
@@ -679,7 +683,9 @@ public class DAO {
                 users.writeEntry(new IndexEntry<UserEntry>(mw.u.getScreenName(), mw.t.getSourceType(), mw.u));
 
                 // record tweet into text file
-                if (mw.dump) message_dump.write(mw.t.toJSON(mw.u, false, Integer.MAX_VALUE, ""));
+                if (mw.dump && writeDump) {
+                    message_dump.write(mw.t.toJSON(mw.u, false, Integer.MAX_VALUE, ""));
+                }
              }
 
             // teach the classifier
@@ -780,7 +786,9 @@ public class DAO {
             if (!created.contains(mw.t.getPostId())) continue;
             synchronized (DAO.class) {
                 // record tweet into text file
-                message_dump.write(mw.t.toJSON(mw.u, false, Integer.MAX_VALUE, ""));
+                if (writeDump) {
+                    message_dump.write(mw.t.toJSON(mw.u, false, Integer.MAX_VALUE, ""));
+                }
              }
 
             // teach the classifier
@@ -802,7 +810,9 @@ public class DAO {
     public static boolean writeAccount(AccountEntry a, boolean dump) {
         try {
             // record account into text file
-            if (dump) account_dump.write(a.toJSON(null));
+            if (dump && writeDump) {
+                account_dump.write(a.toJSON(null));
+            }
 
             // record account into search index
             accounts.writeEntry(new IndexEntry<AccountEntry>(a.getScreenName(), a.getSourceType(), a));
@@ -821,7 +831,9 @@ public class DAO {
     public static boolean writeImportProfile(ImportProfileEntry i, boolean dump) {
         try {
             // record import profile into text file
-            if (dump) import_profile_dump.write(i.toJSON());
+            if (dump && writeDump) {
+                import_profile_dump.write(i.toJSON());
+            }
             // record import profile into search index
             importProfiles.writeEntry(new IndexEntry<ImportProfileEntry>(i.getId(), i.getSourceType(), i));
         } catch (IOException e) {


### PR DESCRIPTION
### Short description

Fixes #1363.

This PR introduces a flag which can be used to enable and disable dump generation. The dump file will be generated, but will nothing will be written on it.

Also, `DumpDownloadDervlet` will throw `403 Forbidden` if requested. The whole file shows as diff because line endings have been changed to UNIX type.

I have:
- [x] There is a corresponding issue for this pull request.
- [x] Mentioned the Issue number in the pull request commit message `Fixes #<number> commit message`
- [x] There is only strictly only one commit per issue.

### For the reviewers
I have:
- [ ] Reviewed this pull request by an authorized contributor.
- [ ] The reviewer is assigned to the pull request.
