### PR TITLE
Fixes #1380: Add YoutubeScraper and WordpressCrawler to search endpoint

### DIFF
--- a/src/org/loklak/api/search/WordpressCrawlerService.java
+++ b/src/org/loklak/api/search/WordpressCrawlerService.java
@@ -84,7 +84,7 @@ public class WordpressCrawlerService extends BaseScraper {
 
    protected Post scrape(BufferedReader br, String type, String url) {
         Post typeArray = new Post(true);
-        typeArray.put(this.scraperName, this.crawlWordpress(this.query, br).toArray());
+        typeArray.put("blogs", this.crawlWordpress(this.query, br).toArray());
         return typeArray;
     }
 

--- a/src/org/loklak/data/DAO.java
+++ b/src/org/loklak/data/DAO.java
@@ -63,8 +63,10 @@ import org.json.JSONObject;
 import org.json.JSONArray;
 import org.loklak.Caretaker;
 import org.loklak.api.search.SearchServlet;
+import org.loklak.api.search.WordpressCrawlerService;
 import org.loklak.geo.GeoNames;
 import org.loklak.harvester.TwitterScraper;
+import org.loklak.harvester.YoutubeScraper;
 import org.loklak.harvester.TwitterScraper.TwitterTweet;
 import org.loklak.api.search.GithubProfileScraper;
 import org.loklak.api.search.QuoraProfileScraper;
@@ -1266,6 +1268,14 @@ public class DAO {
         }
         if (scraperList.contains("instagram") || scraperList.contains("all")) {
             scraperObj = new InstagramProfileScraper(inputMap);
+            scraperObjList.add(scraperObj);
+        }
+        if (scraperList.contains("youtube") || scraperList.contains("all")) {
+            scraperObj = new YoutubeScraper(inputMap);
+            scraperObjList.add(scraperObj);
+        }
+        if (scraperList.contains("wordpress") || scraperList.contains("all")) {
+            scraperObj = new WordpressCrawlerService(inputMap);
             scraperObjList.add(scraperObj);
         }
         //TODO: add more scrapers

--- a/src/org/loklak/harvester/YoutubeScraper.java
+++ b/src/org/loklak/harvester/YoutubeScraper.java
@@ -61,7 +61,6 @@ public class YoutubeScraper extends BaseScraper{
     public YoutubeScraper(Map<String, String> _extra) {
         this();
         this.setExtra(_extra);
-        this.query = this.getExtraValue("query");
     }
 
     public YoutubeScraper(String _query) {
@@ -142,6 +141,7 @@ public class YoutubeScraper extends BaseScraper{
                 this.query = this.query.substring(this.query.length() - 11);
             }
         }
+        this.setExtraValue("query", this.query);
     }
 
     @Override
@@ -155,6 +155,7 @@ public class YoutubeScraper extends BaseScraper{
                 break;
             case "video":
                 postList.addPost(this.parseVideo(br, type, url));
+                out.put("videos", postList.toArray());
                 break;
             case "search":
                 //TODO: Add scraper
@@ -163,7 +164,6 @@ public class YoutubeScraper extends BaseScraper{
                 break;
         }
 
-        out.put(this.scraperName, postList.toArray());
         return out;
     }
 


### PR DESCRIPTION
Fixes Issue #1380 
Example urls: 
1) http://127.0.0.1:9000/api/search.json?query=https://www.youtube.com/watch?v=xZ-m55K3FhQ&scraper=youtube
2) http://127.0.0.1:9000/api/search.json?q=http://blog.fossasia.org/this-api-or-that-library-which-one/&scraper=wordpress

I have:
- [x] There is a corresponding issue for this pull request.
- [x] Mentioned the Issue number in the pull request commit message `Fixes #<number> commit message`
- [x] There is only strictly only one commit per issue.

### For the reviewers
I have:
- [ ] Reviewed this pull request by an authorized contributor.
- [ ] The reviewer is assigned to the pull request.
