### PR TITLE
Fixes 1382: Configure InstagramProfileScraper with BaseScraper and Post

### DIFF
--- a/src/org/loklak/api/search/ConsoleService.java
+++ b/src/org/loklak/api/search/ConsoleService.java
@@ -235,7 +235,9 @@ public class ConsoleService extends AbstractAPIHandler implements APIHandler {
             return json;
         });
         dbAccess.put(Pattern.compile("SELECT +?(.*?) +?FROM +?instagramprofile +?WHERE +?profile ??= ??'(.*?)' ??;"), matcher -> {
-            SusiThought json = InstagramProfileScraper.scrapeInstagram(matcher.group(2));
+            BaseScraper instaScrape = new InstagramProfileScraper(matcher.group(2));
+            Timeline2 dataList = instaScrape.getData();
+            SusiThought json = new SusiThought(dataList.toJSON());
             SusiTransfer transfer = new SusiTransfer(matcher.group(1));
             json.setData(transfer.conclude(json.getData()));
             return json;

--- a/src/org/loklak/api/search/GithubProfileScraper.java
+++ b/src/org/loklak/api/search/GithubProfileScraper.java
@@ -65,7 +65,6 @@ public class GithubProfileScraper extends BaseScraper {
     public GithubProfileScraper(Map<String, String> _extra) {
         this();
         this.setExtra(_extra);
-        this.query = this.getExtraValue("query");
     }
 
     public GithubProfileScraper(String _query) {
@@ -114,6 +113,7 @@ public class GithubProfileScraper extends BaseScraper {
     }
 
     protected void setParam() {
+        this.query = this.getExtraValue("query");
         if(!"".equals(this.getExtraValue("terms"))) {
             this.termsList = Arrays.asList(this.getExtraValue("terms").trim().split("\\s*,\\s*"));
         } else {

--- a/src/org/loklak/data/DAO.java
+++ b/src/org/loklak/data/DAO.java
@@ -68,6 +68,7 @@ import org.loklak.harvester.TwitterScraper;
 import org.loklak.harvester.TwitterScraper.TwitterTweet;
 import org.loklak.api.search.GithubProfileScraper;
 import org.loklak.api.search.QuoraProfileScraper;
+import org.loklak.api.search.InstagramProfileScraper;
 import org.loklak.harvester.BaseScraper;
 import org.loklak.http.AccessTracker;
 import org.loklak.http.ClientConnection;
@@ -75,7 +76,6 @@ import org.loklak.http.RemoteAccess;
 import org.loklak.objects.AbstractObjectEntry;
 import org.loklak.objects.AccountEntry;
 import org.loklak.objects.ImportProfileEntry;
-//import org.loklak.objects.TwitterTweet;
 import org.loklak.objects.Peers;
 import org.loklak.objects.QueryEntry;
 import org.loklak.objects.ResultList;
@@ -1234,7 +1234,7 @@ public class DAO {
         Timeline2 dataSet = new Timeline2(order);
         List<String> scraperList = Arrays.asList(inputMap.get("scraper").trim().split("\\s*,\\s*"));
         List<BaseScraper> scraperObjList = getScraperObjects(scraperList, inputMap);
-        ExecutorService scraperRunner = Executors.newFixedThreadPool(2);
+        ExecutorService scraperRunner = Executors.newFixedThreadPool(scraperObjList.size());
 
         try{
             for (BaseScraper scraper : scraperObjList) {
@@ -1262,6 +1262,10 @@ public class DAO {
         }
         if (scraperList.contains("quora") || scraperList.contains("all")) {
             scraperObj = new QuoraProfileScraper(inputMap);
+            scraperObjList.add(scraperObj);
+        }
+        if (scraperList.contains("instagram") || scraperList.contains("all")) {
+            scraperObj = new InstagramProfileScraper(inputMap);
             scraperObjList.add(scraperObj);
         }
         //TODO: add more scrapers

--- a/src/org/loklak/harvester/BaseScraper.java
+++ b/src/org/loklak/harvester/BaseScraper.java
@@ -59,6 +59,7 @@ public abstract class BaseScraper extends AbstractAPIHandler {
 
     protected void setExtra(Map<String, String> _extra) {
         this.extra = _extra;
+        this.query = _extra.get("query");
         this.setParam();
     }
 

--- a/src/org/loklak/harvester/Post.java
+++ b/src/org/loklak/harvester/Post.java
@@ -37,6 +37,12 @@ public class Post extends JSONObject {
         this();
     }
 
+    public Post(String data, String query) {
+        super(data);
+        this.setTimestamp();
+        this.setPostId(query);
+    }
+
     protected Post(long timestamp) {
         this.setTimestamp(timestamp);
     }


### PR DESCRIPTION
Fixes : 

1) issue #1382 
2) No `query` error in GithubProfileScraper.java appeared while configuring BaseScraper BaseScraper

TODO: 

To filter only useful data from InstagramProfileScraper

I have:
- [x] There is a corresponding issue for this pull request.
- [x] Mentioned the Issue number in the pull request commit message `Fixes #<number> commit message`
- [x] There is only strictly only one commit per issue.

### For the reviewers
I have:
- [ ] Reviewed this pull request by an authorized contributor.
- [ ] The reviewer is assigned to the pull request.
