### PR TITLE
Change backend to root.loklak.org for Kubernetes images

### DIFF
--- a/kubernetes/images/development/Dockerfile
+++ b/kubernetes/images/development/Dockerfile
@@ -16,6 +16,7 @@ RUN apk update && apk add openjdk8 git bash && \
     sed -i.bak 's/^\(elasticsearch_transport.enabled\).*/\1=true/' conf/config.properties && \
     sed -i.bak 's/^\(elasticsearch_transport.addresses\).*/\1=elasticsearch.elasticsearch:9300/' conf/config.properties && \
     sed -i.bak 's/^\(dump.write_enabled\).*/\1=false/' conf/config.properties && \
+    sed -i.bak 's/^\(backend=\).*/\1http:\/\/root.loklak.org/' conf/config.properties && \
     echo "while true; do sleep 10;done" >> bin/start.sh && \
     rm -rf .[^.] .??*
 

--- a/kubernetes/images/master/Dockerfile
+++ b/kubernetes/images/master/Dockerfile
@@ -15,6 +15,7 @@ RUN apk update && apk add openjdk8 git bash && \
     sed -i.bak 's/^\(upgradeInterval=\).*/\186400000000/' conf/config.properties && \
     sed -i.bak 's/^\(elasticsearch_transport.enabled\).*/\1=true/' conf/config.properties && \
     sed -i.bak 's/^\(elasticsearch_transport.addresses\).*/\1=elasticsearch.elasticsearch:9300/' conf/config.properties && \
+    sed -i.bak 's/^\(backend=\).*/\1http:\/\/root.loklak.org/' conf/config.properties && \
     echo "while true; do sleep 10;done" >> bin/start.sh && \
     rm -rf .[^.] .??*
 


### PR DESCRIPTION
### Short description

Fixes #1404.

Example - 
```bash
$ sed -i.bak 's/^\(backend=\).*/\1http:\/\/root.loklak.org/' conf/config.properties
$ git diff
diff --git a/conf/config.properties b/conf/config.properties
index dcc87cc..088880a 100644
--- a/conf/config.properties
+++ b/conf/config.properties
@@ -115,7 +115,7 @@ DoS.servicereduction = 1000
 # peer-to-peer back-end: this is used to assign a 'shadow' peer which
 # receives all message data that this peer creates
 # if you don't want a p2p operation,remove the backend value
-backend=http://api.loklak.org
+backend=http://root.loklak.org
 backend.push.enabled=true
 
 # peer-to-peer front peer: this is used to assign scraping activities to

```

I have:
- [x] There is a corresponding issue for this pull request.
- [x] Mentioned the Issue number in the pull request commit message `Fixes #<number> commit message`
- [x] There is only strictly only one commit per issue.

### For the reviewers
I have:
- [ ] Reviewed this pull request by an authorized contributor.
- [ ] The reviewer is assigned to the pull request.
