### PR TITLE
Refactoring try-finally block to try resource block

### DIFF
--- a/src/org/loklak/LoklakServer.java
+++ b/src/org/loklak/LoklakServer.java
@@ -765,33 +765,23 @@ public class LoklakServer {
 
     	// check http port
         if(!httpsMode.equals(HttpsMode.ONLY)){
-	        ServerSocket ss = null;
-	        try {
-	            ss = new ServerSocket(httpPort);
+	        try (ServerSocket ss = new ServerSocket(httpPort)) {
 	            ss.setReuseAddress(true);
 	            ss.setReceiveBufferSize(65536);
 	        } catch (IOException e) {
 	            // the socket is already occupied by another service
 	            throw new IOException("port " + httpPort + " is already occupied by another service, maybe another loklak is running on this port already. exit.");
-	        } finally {
-	            // close the socket again
-	            if (ss != null) ss.close();
 	        }
         }
 
         // check https port
         if(httpsMode.isGreaterOrEqualTo(HttpsMode.ON)){
-	        ServerSocket sss = null;
-	        try {
-	            sss = new ServerSocket(httpsPort);
+	        try (ServerSocket sss = new ServerSocket(httpsPort)) {
 	            sss.setReuseAddress(true);
 	            sss.setReceiveBufferSize(65536);
 	        } catch (IOException e) {
 	            // the socket is already occupied by another service
 	        	throw new IOException("port " + httpsPort + " is already occupied by another service, maybe another loklak is running on this port already. exit.");
-	        } finally {
-	            // close the socket again
-	            if (sss != null) sss.close();
 	        }
         }
     }


### PR DESCRIPTION
### Short description
I have:
Refactoring try-finally block to try-with-resource block.

 Introduced in Java 7, try-with-resource block is the recommended way to close a Closable object, leading to more manageable and defensive code.

I suggest that we should find more of these try-finally block and replace it with try-with-resource. It is pretty secure way to enhance readability and manageability of the code.

See: 
https://docs.oracle.com/javase/tutorial/essential/exceptions/tryResourceClose.html
https://stackoverflow.com/questions/17739362/java7-try-with-resources-statement-advantage


### For the reviewers
I have:
- [x] Reviewed this pull request by an authorized contributor.
- [x] The reviewer is assigned to the pull request.