### PR TITLE
fixes #1450 - fixes links in Quora profile data - feeds

### DIFF
--- a/src/org/loklak/api/search/QuoraProfileScraper.java
+++ b/src/org/loklak/api/search/QuoraProfileScraper.java
@@ -359,7 +359,7 @@ public class QuoraProfileScraper extends BaseScraper {
         for (Element count: counts) {
             String topic = count.parent().text();
             topic = topic.substring(0, topic.indexOf(count.text())).trim();
-            feeds.put(topic.toLowerCase() + "_url", baseUrl + count.parent().attr("href"));
+            feeds.put(topic.toLowerCase() + "_url", baseUrl + count.parent().attr("href").substring(1));
             feeds.put(topic.toLowerCase(), count.text());
         }
         quoraProfile.put("feeds", feeds);


### PR DESCRIPTION
Fixes issue #1450, removed double '/' after base url in feed
links.

I have:
- [x] There is a corresponding issue for this pull request.
- [x] Mentioned the Issue number in the pull request commit message `Fixes #<number> commit message`
- [x] There is only strictly only one commit per issue.

### For the reviewers
I have:
- [ ] Reviewed this pull request by an authorized contributor.
- [ ] The reviewer is assigned to the pull request.
