### PR TITLE
Disable streaming for staging deployment

### DIFF
--- a/kubernetes/images/staging/Dockerfile
+++ b/kubernetes/images/staging/Dockerfile
@@ -16,12 +16,8 @@ RUN apk update && apk add openjdk8 git bash && \
     sed -i.bak 's/^\(elasticsearch_transport.enabled\).*/\1=true/' conf/config.properties && \
     sed -i.bak 's/^\(elasticsearch_transport.addresses\).*/\1=elasticsearch.elasticsearch:9300/' conf/config.properties && \
     sed -i.bak 's/^\(dump.write_enabled\).*/\1=false/' conf/config.properties && \
-    sed -i.bak 's/^\(stream.enabled\).*/\1=true/' conf/config.properties && \
-    sed -i.bak 's/^\(stream.mqtt.address\).*/\1=tcp:\/\/mosquitto.mqtt:1883/' conf/config.properties && \
     echo "while true; do sleep 10;done" >> bin/start.sh
 
 
 # Start
 CMD ["bin/start.sh", "-Idn"]
-
-RUN rm -rf .[^.] .??*


### PR DESCRIPTION
### Short description

Fixes #1475.

The current deployment is failing as `MqttClient` can't find Mosquitto service. As a workaround to make the deployment working again, I have disabled streaming in this PR.

I have:
- [x] There is a corresponding issue for this pull request.
- [x] Mentioned the Issue number in the pull request commit message `Fixes #<number> commit message`
- [x] There is only strictly only one commit per issue.

### For the reviewers
I have:
- [ ] Reviewed this pull request by an authorized contributor.
- [ ] The reviewer is assigned to the pull request.
