### PR TITLE
Fixes 1290: Index data from multiple scrapers

### DIFF
--- a/src/org/loklak/DumpImporter.java
+++ b/src/org/loklak/DumpImporter.java
@@ -31,6 +31,7 @@ import org.json.JSONObject;
 import org.loklak.data.DAO;
 import org.loklak.data.IndexEntry;
 import org.loklak.harvester.TwitterScraper.TwitterTweet;
+import org.loklak.harvester.Post;
 
 import org.loklak.objects.UserEntry;
 import org.loklak.tools.storage.JsonFactory;
@@ -91,7 +92,7 @@ public class DumpImporter extends Thread {
                         JsonFactory tweet;
                         try {
                             List<IndexEntry<UserEntry>> userBulk = new ArrayList<>();
-                            List<IndexEntry<TwitterTweet>> messageBulk = new ArrayList<>();
+                            List<IndexEntry<Post>> messageBulk = new ArrayList<>();
                             while ((tweet = dumpReader.take()) != JsonStreamReader.POISON_JSON_MAP) {
                                 try {
                                     JSONObject json = tweet.getJSON();
@@ -101,7 +102,7 @@ public class DumpImporter extends Thread {
                                     TwitterTweet t = new TwitterTweet(json);
                                     // record user into search index
                                     userBulk.add(new IndexEntry<UserEntry>(u.getScreenName(), t.getSourceType(), u));
-                                    messageBulk.add(new IndexEntry<TwitterTweet>(t.getPostId(), t.getSourceType(), t));
+                                    messageBulk.add(new IndexEntry<Post>(t.getPostId(), t.getSourceType(), t));
                                     if (userBulk.size() > 1500 || messageBulk.size() > 1500) {
                                         DAO.users.writeEntries(userBulk);
                                         DAO.messages.writeEntries(messageBulk);

--- a/src/org/loklak/api/search/ShortlinkFromTweetServlet.java
+++ b/src/org/loklak/api/search/ShortlinkFromTweetServlet.java
@@ -58,7 +58,7 @@ public class ShortlinkFromTweetServlet extends HttpServlet {
             id = id.substring(0, p);
         }
         
-        TwitterTweet message = DAO.readMessage(id);
+        TwitterTweet message = (TwitterTweet) DAO.readMessage(id);
         if (message == null) {
             // try to get that from the incoming message buffer
             message = LoklakServer.queuedIndexing.readMessage(id);

--- a/src/org/loklak/data/DAO.java
+++ b/src/org/loklak/data/DAO.java
@@ -65,6 +65,7 @@ import org.loklak.Caretaker;
 import org.loklak.api.search.SearchServlet;
 import org.loklak.api.search.WordpressCrawlerService;
 import org.loklak.geo.GeoNames;
+import org.loklak.harvester.Post;
 import org.loklak.harvester.TwitterScraper;
 import org.loklak.harvester.YoutubeScraper;
 import org.loklak.harvester.TwitterScraper.TwitterTweet;
@@ -679,18 +680,18 @@ public class DAO {
                 // and check if the message exists
                 boolean exists = false;
                 if (mw.t.getCreatedAt().after(DateParser.oneHourAgo())) {
-                    exists = messages_hour.writeEntry(new IndexEntry<TwitterTweet>(mw.t.getPostId(), mw.t.getSourceType(), mw.t));
+                    exists = messages_hour.writeEntry(new IndexEntry<Post>(mw.t.getPostId(), mw.t.getSourceType(), mw.t));
                     if (exists) return false;
                 }
                 if (mw.t.getCreatedAt().after(DateParser.oneDayAgo())) {
-                    exists = messages_day.writeEntry(new IndexEntry<TwitterTweet>(mw.t.getPostId(), mw.t.getSourceType(), mw.t));
+                    exists = messages_day.writeEntry(new IndexEntry<Post>(mw.t.getPostId(), mw.t.getSourceType(), mw.t));
                     if (exists) return false;
                 }
                 if (mw.t.getCreatedAt().after(DateParser.oneWeekAgo())) {
-                    exists = messages_week.writeEntry(new IndexEntry<TwitterTweet>(mw.t.getPostId(), mw.t.getSourceType(), mw.t));
+                    exists = messages_week.writeEntry(new IndexEntry<Post>(mw.t.getPostId(), mw.t.getSourceType(), mw.t));
                     if (exists) return false;
                 }
-                exists = messages.writeEntry(new IndexEntry<TwitterTweet>(mw.t.getPostId(), mw.t.getSourceType(), mw.t));
+                exists = messages.writeEntry(new IndexEntry<Post>(mw.t.getPostId(), mw.t.getSourceType(), mw.t));
                 if (exists) return false;
 
                 // write the user into the index
@@ -720,8 +721,68 @@ public class DAO {
         }
         Set<String> createdIDs = new HashSet<>();
         createdIDs.addAll(writeMessageBulkNoDump(noDump));
-        createdIDs.addAll(writeMessageBulkDump(dump)); // does also do an writeMessageBulkNoDump internally
+        // does also do an writeMessageBulkNoDump internally
+        createdIDs.addAll(writeMessageBulkDump(dump));
         return createdIDs;
+    }
+
+    public static Set<String> writeMessageBulk(Set<Timeline2> postBulk) {
+        for (Timeline2 postList: postBulk) {
+            if (postList.size() < 1) continue;
+            if(postList.dump) {
+                writeMessageBulkDump(postList);
+            }
+            writeMessageBulkNoDump(postList);
+        }
+        //TODO: return total dumped, or IDs dumped to create hash of IDs
+        return new HashSet<>();
+    }
+
+    private static Set<String> writeMessageBulkNoDump(Timeline2 postList) {
+        if (postList.size() == 0) return new HashSet<>();
+        List<Post> messageBulk = new ArrayList<>();
+
+        for (Post post: postList) {
+            if (messages.existsCache(post.getPostId())) {
+                continue;
+            }
+            synchronized (DAO.class) {
+                messageBulk.add(post);
+            }
+        }
+        ElasticsearchClient.BulkWriteResult result = null;
+        try {
+            Date limitDate = new Date();
+            limitDate.setTime(DateParser.oneHourAgo().getTime());
+            List<Post> macc = new ArrayList<Post>();
+            final Set<String> existed = new HashSet<>();
+            long hourLong = limitDate.getTime();
+            for(Post post : messageBulk) {
+                if(hourLong <= post.getTimestamp()) macc.add(post);
+            }
+            
+            result = messages_hour.writeEntries(macc);
+            for (Post i: macc) if (!(result.getCreated().contains(i.getPostId()))) existed.add(i.getPostId());
+
+            limitDate.setTime(DateParser.oneDayAgo().getTime());
+            macc = messageBulk.stream().filter(i -> !(existed.contains(i.getPostId()))).filter(i -> i.getCreated().after(limitDate)).collect(Collectors.toList());
+            result = messages_day.writeEntries(macc);
+            for (Post i: macc) if (!(result.getCreated().contains(i.getPostId()))) existed.add(i.getPostId());
+
+            limitDate.setTime(DateParser.oneWeekAgo().getTime());
+            macc = messageBulk.stream().filter(i -> !(existed.contains(i.getPostId())))
+                    .filter(i -> i.getCreated().after(limitDate)).collect(Collectors.toList());
+            result = messages_week.writeEntries(macc);
+            for (Post i: macc) if (!(result.getCreated().contains(i.getPostId()))) existed.add(i.getPostId());
+
+            macc = messageBulk.stream().filter(i -> !(existed.contains(i.getPostId()))).collect(Collectors.toList());
+            result = messages.writeEntries(macc);
+            for (Post i: macc) if (!(result.getCreated().contains(i.getPostId()))) existed.add(i.getPostId());
+        } catch (IOException e) {
+        	Log.getLog().warn(e);
+        }
+        if (result == null) return new HashSet<String>();
+        return result.getCreated();
     }
 
     /**
@@ -732,7 +793,7 @@ public class DAO {
     private static Set<String> writeMessageBulkNoDump(Collection<MessageWrapper> mws) {
         if (mws.size() == 0) return new HashSet<>();
         List<IndexEntry<UserEntry>> userBulk = new ArrayList<>();
-        List<IndexEntry<TwitterTweet>> messageBulk = new ArrayList<>();
+        List<IndexEntry<Post>> messageBulk = new ArrayList<>();
         for (MessageWrapper mw: mws) {
             if (messages.existsCache(mw.t.getPostId())) continue; // we omit writing this again
             synchronized (DAO.class) {
@@ -740,7 +801,7 @@ public class DAO {
                 userBulk.add(new IndexEntry<UserEntry>(mw.u.getScreenName(), mw.t.getSourceType(), mw.u));
 
                 // record tweet into search index
-                messageBulk.add(new IndexEntry<TwitterTweet>(mw.t.getPostId(), mw.t.getSourceType(), mw.t));
+                messageBulk.add(new IndexEntry<Post>(mw.t.getPostId(), mw.t.getSourceType(), mw.t));
              }
 
             // teach the classifier
@@ -749,40 +810,40 @@ public class DAO {
         ElasticsearchClient.BulkWriteResult result = null;
         try {
             final Date limitDate = new Date();
-            List<IndexEntry<TwitterTweet>> macc;
+            List<IndexEntry<Post>> macc;
             final Set<String> existed = new HashSet<>();
 
             //DAO.log("***DEBUG messages     INIT: " + messageBulk.size());
 
             limitDate.setTime(DateParser.oneHourAgo().getTime());
-            macc = messageBulk.stream().filter(i -> i.getObject().getCreatedAt().after(limitDate)).collect(Collectors.toList());
+            macc = messageBulk.stream().filter(i -> i.getObject().getCreated().after(limitDate)).collect(Collectors.toList());
             //DAO.log("***DEBUG messages for HOUR: " + macc.size());
             result = messages_hour.writeEntries(macc);
             //DAO.log("***DEBUG messages for HOUR: " + result.getCreated().size() + "  created");
-            for (IndexEntry<TwitterTweet> i: macc) if (!(result.getCreated().contains(i.getId()))) existed.add(i.getId());
+            for (IndexEntry<Post> i: macc) if (!(result.getCreated().contains(i.getId()))) existed.add(i.getId());
             //DAO.log("***DEBUG messages for HOUR: " + existed.size() + "  existed");
 
             limitDate.setTime(DateParser.oneDayAgo().getTime());
-            macc = messageBulk.stream().filter(i -> !(existed.contains(i.getObject().getPostId()))).filter(i -> i.getObject().getCreatedAt().after(limitDate)).collect(Collectors.toList());
+            macc = messageBulk.stream().filter(i -> !(existed.contains(i.getObject().getPostId()))).filter(i -> i.getObject().getCreated().after(limitDate)).collect(Collectors.toList());
             //DAO.log("***DEBUG messages for  DAY : " + macc.size());
             result = messages_day.writeEntries(macc);
             //DAO.log("***DEBUG messages for  DAY: " + result.getCreated().size() + " created");
-            for (IndexEntry<TwitterTweet> i: macc) if (!(result.getCreated().contains(i.getId()))) existed.add(i.getId());
+            for (IndexEntry<Post> i: macc) if (!(result.getCreated().contains(i.getId()))) existed.add(i.getId());
             //DAO.log("***DEBUG messages for  DAY: " + existed.size()  + "  existed");
 
             limitDate.setTime(DateParser.oneWeekAgo().getTime());
-            macc = messageBulk.stream().filter(i -> !(existed.contains(i.getObject().getPostId()))).filter(i -> i.getObject().getCreatedAt().after(limitDate)).collect(Collectors.toList());
+            macc = messageBulk.stream().filter(i -> !(existed.contains(i.getObject().getPostId()))).filter(i -> i.getObject().getCreated().after(limitDate)).collect(Collectors.toList());
             //DAO.log("***DEBUG messages for WEEK: " + macc.size());
             result = messages_week.writeEntries(macc);
             //DAO.log("***DEBUG messages for WEEK: " + result.getCreated().size() + "  created");
-            for (IndexEntry<TwitterTweet> i: macc) if (!(result.getCreated().contains(i.getId()))) existed.add(i.getId());
+            for (IndexEntry<Post> i: macc) if (!(result.getCreated().contains(i.getId()))) existed.add(i.getId());
             //DAO.log("***DEBUG messages for WEEK: " + existed.size()  + "  existed");
 
             macc = messageBulk.stream().filter(i -> !(existed.contains(i.getObject().getPostId()))).collect(Collectors.toList());
             //DAO.log("***DEBUG messages for  ALL : " + macc.size());
             result = messages.writeEntries(macc);
             //DAO.log("***DEBUG messages for  ALL: " + result.getCreated().size() + "  created");
-            for (IndexEntry<TwitterTweet> i: macc) if (!(result.getCreated().contains(i.getId()))) existed.add(i.getId());
+            for (IndexEntry<Post> i: macc) if (!(result.getCreated().contains(i.getId()))) existed.add(i.getId());
             //DAO.log("***DEBUG messages for  ALL: " + existed.size()  + "  existed");
 
             users.writeEntries(userBulk);
@@ -813,6 +874,23 @@ public class DAO {
         	Log.getLog().warn(e);
         }
 
+        return created;
+    }
+
+    private static Set<String> writeMessageBulkDump(Timeline2 postList) {
+        Set<String> created = writeMessageBulkNoDump(postList);
+
+        for (Post post: postList) try {
+            if (!created.contains(post.getPostId())) continue;
+            synchronized (DAO.class) {
+                // record tweet into text file
+                if (writeDump) {
+                    message_dump.write(post);
+                }
+            }
+        } catch (IOException e) {
+        	Log.getLog().warn(e);
+        }
         return created;
     }
 
@@ -918,8 +996,8 @@ public class DAO {
         return elasticsearch_client.count(IndexName.accounts.name(), AbstractObjectEntry.TIMESTAMP_FIELDNAME, -1);
     }
 
-    public static TwitterTweet readMessage(String id) throws IOException {
-        TwitterTweet m = null;
+    public static Post readMessage(String id) throws IOException {
+        Post m = null;
         return messages_hour != null && ((m = messages_hour.read(id)) != null) ? m :
                messages_day  != null && ((m = messages_day.read(id))  != null) ? m :
                messages_week != null && ((m = messages_week.read(id)) != null) ? m :
@@ -956,6 +1034,7 @@ public class DAO {
 
     public static class SearchLocalMessages {
         public Timeline timeline;
+        public Timeline2 postList;
         public Map<String, List<Map.Entry<String, Long>>> aggregations;
         public ElasticsearchClient.Query query;
 
@@ -1003,6 +1082,13 @@ public class DAO {
                             this.query =  elasticsearch_client.query((resultIndex = IndexName.messages).name(), sq.queryBuilder, orderField.getMessageFieldName(), timezoneOffset, resultCount, interval, AbstractObjectEntry.CREATED_AT_FIELDNAME, aggregationLimit, aggregationFields);
                 }}}
             }
+            this.query = elasticsearch_client.query(
+                        (resultIndex = IndexName.messages_day).name(),
+                        sq.queryBuilder,
+                        orderField.getMessageFieldName(),
+                        resultCount
+                );
+                
             timeline.setHits(query.hitCount);
             timeline.setResultIndex(resultIndex);
 
@@ -1041,8 +1127,72 @@ public class DAO {
             );
         }
 
-        private static boolean insufficient(ElasticsearchClient.Query query, int resultCount, int aggregationLimit, String... aggregationFields) {
-            return query.hitCount < resultCount || (aggregationFields.length > 0 && getAggregationResultLimit(query.aggregations) < aggregationLimit);
+        public SearchLocalMessages (
+                Map<String, Map<String, String>> inputMap,
+                final Timeline2.Order orderField,
+                final int resultCount
+        ) {
+            this.postList = new Timeline2(orderField);
+            IndexName resultIndex;
+            QueryEntry.ElasticsearchQuery sq = new QueryEntry.ElasticsearchQuery(
+                    inputMap.get("get"), inputMap.get("not_get"), inputMap.get("also_get"));
+
+            this.query = elasticsearch_client.query(
+                    (resultIndex = IndexName.messages_hour).name(),
+                    sq.queryBuilder,
+                    orderField.getMessageFieldName(),
+                    resultCount
+            );
+
+            if (this.query.hitCount < resultCount) {
+                this.query =  elasticsearch_client.query(
+                        (resultIndex = IndexName.messages_day).name(),
+                        sq.queryBuilder,
+                        orderField.getMessageFieldName(),
+                        resultCount
+                );
+            }
+
+            if (this.query.hitCount < resultCount) {
+                this.query =  elasticsearch_client.query(
+                        (resultIndex = IndexName.messages_week).name(),
+                        sq.queryBuilder,
+                        orderField.getMessageFieldName(),
+                        resultCount
+                );
+            }
+
+            if (this.query.hitCount < resultCount) {
+                this.query =  elasticsearch_client.query(
+                        (resultIndex = IndexName.messages).name(),
+                        sq.queryBuilder,
+                        orderField.getMessageFieldName(),
+                        resultCount
+                );
+            }
+
+            // Feed search results to postList
+            this.postList.setResultIndex(resultIndex);
+
+            addResults();
+        }
+
+        private void addResults() {
+            Post outputPost;
+            for (Map<String, Object> map: this.query.result) {
+                outputPost = new Post(map);
+                this.postList.addPost(outputPost);
+            }
+        }
+
+        private static boolean insufficient(
+                ElasticsearchClient.Query query,
+                int resultCount,
+                int aggregationLimit,
+                String... aggregationFields
+        ) {
+            return query.hitCount < resultCount || (aggregationFields.length > 0
+                    && getAggregationResultLimit(query.aggregations) < aggregationLimit);
         }
 
         public JSONObject getAggregations() {
@@ -1256,6 +1406,7 @@ public class DAO {
             for (BaseScraper scraper : scraperObjList) {
                 scraperRunner.execute(() -> {
                     dataSet.add(scraper.getData());
+                    
                 });
             }
         } finally {

--- a/src/org/loklak/data/IncomingMessageBuffer.java
+++ b/src/org/loklak/data/IncomingMessageBuffer.java
@@ -21,13 +21,15 @@ package org.loklak.data;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
+import java.util.HashSet;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.atomic.AtomicInteger;
-
 import org.eclipse.jetty.util.log.Log;
 import org.loklak.harvester.TwitterScraper.TwitterTweet;
 import org.loklak.objects.Timeline;
+import org.loklak.objects.Timeline2;
 import org.loklak.objects.UserEntry;
 
 public class IncomingMessageBuffer extends Thread {
@@ -35,6 +37,7 @@ public class IncomingMessageBuffer extends Thread {
     private final static int MESSAGE_QUEUE_MAXSIZE = 100000;
     //private final static int bufferLimit = MESSAGE_QUEUE_MAXSIZE * 3 / 4;
     private static BlockingQueue<DAO.MessageWrapper> messageQueue = new ArrayBlockingQueue<DAO.MessageWrapper>(MESSAGE_QUEUE_MAXSIZE);
+    private static BlockingQueue<Timeline2> postQueue = new ArrayBlockingQueue<Timeline2>(MESSAGE_QUEUE_MAXSIZE);
     private static AtomicInteger queueClients = new AtomicInteger(0);
 
     private boolean shallRun = true, isBusy = false;
@@ -77,12 +80,11 @@ public class IncomingMessageBuffer extends Thread {
 
     @Override
     public void run() {
-
         // work loop
         loop: while (this.shallRun) try {
             this.isBusy = false;
 
-            if (messageQueue.isEmpty() || !DAO.wait_ready(1000)) {
+            if ((messageQueue.isEmpty() && postQueue.isEmpty()) || !DAO.wait_ready(1000)) {
                 // in case that the queue is empty, try to fill it with previously pushed content
                 //List<Map<String, Object>> shard = this.jsonBufferHandler.getBufferShard();
                 // if the shard has content, turn this into messages again
@@ -92,47 +94,66 @@ public class IncomingMessageBuffer extends Thread {
                 try {Thread.sleep(10000);} catch (InterruptedException e) {}
                 continue loop;
             }
-
-            DAO.MessageWrapper mw;
             this.isBusy = true;
-            AtomicInteger candMessages = new AtomicInteger();
-            AtomicInteger knownMessagesCache = new AtomicInteger();
-            int maxBulkSize = 200;
-            List<DAO.MessageWrapper> bulk = new ArrayList<>();
-            pollloop: while ((mw = messageQueue.poll()) != null) {
-                if (DAO.messages.existsCache(mw.t.getPostId())) {
-                     knownMessagesCache.incrementAndGet();
-                     continue pollloop;
-                }
-                candMessages.incrementAndGet();
-
-                // in case that the message queue is too large, dump the queue into a file here
-                // to make room that clients can continue to push without blocking
-                /*
-                if (messageQueue.size() > bufferLimit) {
-                    this.jsonBufferHandler.buffer(mw.t.getCreatedAt(), mw.t.toMap(mw.u, false, Integer.MAX_VALUE, ""));
-                    continue pollloop;
-                }
-                */
-                // if there is time enough to finish this, continue to write into the index
-
-                mw.t.enrich(); // we enrich here again because the remote peer may have done this with an outdated version or not at all
-                bulk.add(mw);
-                if (bulk.size() >= maxBulkSize) {
-                    dumpbulk(bulk, candMessages, knownMessagesCache);
-                    bulk.clear();
-                }
-            }
-            if (bulk.size() >= 0) {
-                dumpbulk(bulk, candMessages, knownMessagesCache);
-                bulk.clear();
-            }
+            if(messageQueue.size() > 0) indexTweets();
+            else if(postQueue.size() > 0) indexPosts();
             this.isBusy = false;
+
         } catch (Throwable e) {
             Log.getLog().warn("QueuedIndexing THREAD", e);
         }
 
         Log.getLog().info("QueuedIndexing terminated");
+    }
+
+    private void indexPosts() {
+        int maxBulkSize = 1;
+        Timeline2 postListObj = null;
+        Set<Timeline2> bulk = new HashSet<Timeline2>();
+
+        while((postListObj = postQueue.poll()) != null) {
+            bulk.add(postListObj);
+            if (bulk.size() >= maxBulkSize) {
+                dumpbulk(bulk);
+                bulk.clear();
+            }
+        }
+    }
+
+    private void indexTweets() {
+        DAO.MessageWrapper mw;
+        AtomicInteger candMessages = new AtomicInteger();
+        AtomicInteger knownMessagesCache = new AtomicInteger();
+        int maxBulkSize = 200;
+        List<DAO.MessageWrapper> bulk = new ArrayList<>();
+        pollloop: while ((mw = messageQueue.poll()) != null) {
+            if (DAO.messages.existsCache(mw.t.getPostId())) {
+                 knownMessagesCache.incrementAndGet();
+                 continue pollloop;
+            }
+            candMessages.incrementAndGet();
+
+            // in case that the message queue is too large, dump the queue into a file here
+            // to make room that clients can continue to push without blocking
+            /*
+            if (messageQueue.size() > bufferLimit) {
+                this.jsonBufferHandler.buffer(mw.t.getCreatedAt(), mw.t.toMap(mw.u, false, Integer.MAX_VALUE, ""));
+                continue pollloop;
+            }
+            */
+            // if there is time enough to finish this, continue to write into the index
+
+            mw.t.enrich(); // we enrich here again because the remote peer may have done this with an outdated version or not at all
+            bulk.add(mw);
+            if (bulk.size() >= maxBulkSize) {
+                dumpbulk(bulk, candMessages, knownMessagesCache);
+                bulk.clear();
+            }
+        }
+        if (bulk.size() >= 0) {
+            dumpbulk(bulk, candMessages, knownMessagesCache);
+            bulk.clear();
+        }
     }
 
     private void dumpbulk(List<DAO.MessageWrapper> bulk, AtomicInteger candMessages, AtomicInteger knownMessagesCache) {
@@ -144,6 +165,12 @@ public class IncomingMessageBuffer extends Thread {
         DAO.log("dumped timelines: " + candMessages + " new " + knownMessagesCache + " known from cache, storage time: " + (dumpfinish - dumpstart) + " ms, remaining messages: " + messageQueue.size());
         candMessages.set(0);
         knownMessagesCache.set(0);
+    }
+
+    private void dumpbulk(Set<Timeline2> bulk) {
+        //TODO: use this
+        int notWrittenDouble = DAO.writeMessageBulk(bulk).size();
+        DAO.log("dumped timelines: "  + postQueue.size());
     }
 
     public static void addScheduler(Timeline tl, final boolean dump) {
@@ -158,6 +185,16 @@ public class IncomingMessageBuffer extends Thread {
         } catch (InterruptedException e) {
         	Log.getLog().warn(e);
         }
+    }
+
+    public static void addScheduler(Timeline2 postList) {
+        queueClients.incrementAndGet();
+       try {
+            postQueue.put(postList);
+        } catch (InterruptedException e) {
+        	DAO.severe(e);
+        }
+        queueClients.decrementAndGet();
     }
 
     public static boolean addSchedulerAvailable() {

--- a/src/org/loklak/data/IndexFactory.java
+++ b/src/org/loklak/data/IndexFactory.java
@@ -22,8 +22,10 @@ package org.loklak.data;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Set;
+import java.util.List;
 
 import org.json.JSONObject;
+import org.loklak.harvester.Post;
 import org.loklak.objects.ObjectEntry;
 import org.loklak.objects.SourceType;
 
@@ -42,8 +44,12 @@ public interface IndexFactory<Entry extends ObjectEntry> {
     public JSONObject readJSON(String id);
 
     public boolean writeEntry(IndexEntry<Entry> entry) throws IOException;
+
+    public boolean writeEntry(JSONObject json) throws IOException;
     
     public ElasticsearchClient.BulkWriteResult writeEntries(Collection<IndexEntry<Entry>> entries) throws IOException;
+
+    public ElasticsearchClient.BulkWriteResult writeEntries(List<Post> entries) throws IOException;
     
     public void close();
     

--- a/src/org/loklak/data/MessageFactory.java
+++ b/src/org/loklak/data/MessageFactory.java
@@ -20,9 +20,10 @@
 package org.loklak.data;
 
 import org.json.JSONObject;
+import org.loklak.harvester.Post;
 import org.loklak.harvester.TwitterScraper.TwitterTweet;
 
-public class MessageFactory extends AbstractIndexFactory<TwitterTweet> implements IndexFactory<TwitterTweet> {
+public class MessageFactory extends AbstractIndexFactory<Post> implements IndexFactory<Post> {
 
     public MessageFactory(final ElasticsearchClient elasticsearch_client, final String index_name, final int cacheSize, final int existSize) {
         super(elasticsearch_client, index_name, cacheSize, existSize);

--- a/src/org/loklak/harvester/Post.java
+++ b/src/org/loklak/harvester/Post.java
@@ -1,9 +1,12 @@
 package org.loklak.harvester;
 
 import java.util.Date;
+import java.util.Map;
 import org.json.JSONObject;
 import org.loklak.data.DAO;
 import org.loklak.objects.ObjectEntry;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
 
 /**
  * @author vibhcool (Vibhor Verma)
@@ -15,8 +18,9 @@ import org.loklak.objects.ObjectEntry;
 public class Post extends JSONObject implements ObjectEntry {
 
     protected long timestamp = 0;
-    protected String postId;
+    protected String postId = null;
     private boolean wrapper = false;
+    private Date createdAt = null;
 
     public Post() {
         this.setTimestamp();
@@ -39,6 +43,10 @@ public class Post extends JSONObject implements ObjectEntry {
         super(json.toString());
     }
 
+    public Post(Map<String, Object> map) {
+        super(map);
+    }
+
     public Post(String data, String query) {
         super(data);
         this.setTimestamp();
@@ -50,17 +58,21 @@ public class Post extends JSONObject implements ObjectEntry {
     }
 
     public long getTimestamp() {
+        if(this.timestamp == 0 && this.has("timestamp_id")) {
+            this.timestamp = Long.parseLong(String.valueOf(this.get("timestamp_id")));
+        }
+        this.setTimestamp(this.timestamp);
         return this.timestamp;
     }
 
     public void setTimestamp(long timestamp) {
-        this.put("timestamp", timestamp);
+        this.put("timestamp_id", timestamp);
         this.timestamp = timestamp;
     }
 
     public void setTimestamp() {
-        if(this.has("timestamp")) {
-            long timestampValue = Long.parseLong(String.valueOf(this.get("timestamp")));
+        if(this.has("timestamp_id")) {
+            long timestampValue = Long.parseLong(String.valueOf(this.get("timestamp_id")));
             this.setTimestamp(timestampValue);
         } else {
             long timestamp = System.currentTimeMillis();
@@ -69,23 +81,45 @@ public class Post extends JSONObject implements ObjectEntry {
     }
 
     public Date getTimestampDate() {
-        return new Date(this.timestamp);
+        DAO.log("date is " + String.valueOf(this.getTimestamp()) + "    " + String.valueOf(new Date(this.getTimestamp())));
+        return new Date(this.getTimestamp());
+    }
+
+    public DateTime getTimestampDate(String a) {
+        DAO.log("date is " + String.valueOf(this.getTimestamp()) + "    " + String.valueOf(new Date(this.getTimestamp())));
+        return new DateTime(this.getTimestamp(), DateTimeZone.UTC);
+    }
+
+    // if the Post doesn't have 
+    public Date getCreated() {
+        if(this.createdAt == null) {
+            return this.getTimestampDate();
+        } else {
+            return this.createdAt;
+        }
+    }
+
+    public void setCreated(Date _createdAt) {
+        this.createdAt = _createdAt;
     }
 
     private void setPostId() {
-        if(this.has("post_id")) {
-            this.setPostId(String.valueOf(this.get("post_id")));
+        if(this.has("id_str")) {
+            this.setPostId(String.valueOf(this.get("id_str")));
         } else {
             this.setPostId(String.valueOf(this.getTimestamp()));
         }
     }
 
     public void setPostId(String postId) {
-        this.put("post_id", postId);
+        this.put("id_str", postId);
         this.postId = postId;
     }
 
     public String getPostId() {
+        if(this.has("id_str")) {
+            this.postId = String.valueOf(this.get("id_str"));
+        }
         return this.postId;
     }
 
@@ -93,7 +127,7 @@ public class Post extends JSONObject implements ObjectEntry {
         return this.wrapper;
     }
 
-    public String toString(){
+    public String toString() {
         return super.toString();
     }
 

--- a/src/org/loklak/harvester/YoutubeScraper.java
+++ b/src/org/loklak/harvester/YoutubeScraper.java
@@ -30,6 +30,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -146,6 +147,18 @@ public class YoutubeScraper extends BaseScraper {
     }
 
     @Override
+    protected void setCacheMap() {
+        this.cacheMap = new HashMap<String, Map<String, String>>();
+
+        Map<String, String> getMap = new HashMap<String, String>();
+        getMap.put("id_str", String.valueOf(this.query));
+        getMap.put("post_type", "video");
+        getMap.put("post_scraper", this.scraperName);
+
+        this.cacheMap.put("get", getMap);
+    }
+
+    @Override
     protected Post scrape(BufferedReader br, String type, String url) {
         Post out = new Post(true);
         Timeline2 postList = new Timeline2(this.order);
@@ -155,7 +168,7 @@ public class YoutubeScraper extends BaseScraper {
                 break;
             case "video":
                 postList.addPost(this.parseVideo(br, type, url));
-                out.put("videos", postList.toArray());
+                this.putData(out, "videos", postList);
                 break;
             case "search":
                 //TODO: Add scraper
@@ -196,10 +209,16 @@ public class YoutubeScraper extends BaseScraper {
 
     public Post parseVideo(final BufferedReader br, String type, String url) {
         String input = "";
-        Post json = new Post(true);
+        Post json = new Post();
         boolean parse_span = false, parse_license = false;
         // values for span
-        String itemProp = "";
+        String itemprop= "";
+        String itemtype = "";
+
+        json.setPostId(url.substring(url.length() - 11));
+        json.put("post_type", "video");
+        json.put("post_scraper", this.scraperName);
+                String itemProp = "";
         String itemType = "";
         try {
             while ((input = br.readLine()) != null) {

--- a/test/org/loklak/api/search/GithubProfileScraperTest.java
+++ b/test/org/loklak/api/search/GithubProfileScraperTest.java
@@ -47,7 +47,7 @@ public class GithubProfileScraperTest {
         Post fetchedProfile = githubScraper.scrapeGithub(profile, br);
 
         assertEquals(fetchedProfile.getString("short_description"), shortDescription);
-        assertEquals(fetchedProfile.getString("user_name"), userName);
+        assertEquals(fetchedProfile.getString("user"), userName);
         assertEquals(fetchedProfile.getString("user_id"), userId);
         assertEquals(fetchedProfile.getString("location"), location);
         assertEquals(fetchedProfile.getString("special_link"), specialLink);
@@ -81,7 +81,7 @@ public class GithubProfileScraperTest {
 
             Post fetchedProfile = githubScraper.scrapeGithub(profile, br);
 
-            assertEquals(fetchedProfile.getString("user_name"), userName);
+            assertEquals(fetchedProfile.getString("user"), userName);
             assertEquals(fetchedProfile.getString("full_name"), fullName);
             assertEquals(fetchedProfile.getString("special_link"), specialLink);
             assertEquals(fetchedProfile.getString("user_id"), userId);


### PR DESCRIPTION
Fixes Issue #1290 , closes #1129 

This PR adds indexing for the scrapers. Right now, this supports indexing for GithubScraper, QuoraScraper and YoutubeScraper.

Indexing: 
1) the data scraped from website is written to index in Timeline2 iterator implemented in BaseScraper. 2) If a scraper class has setCacheMap() implemented, it will be indexed
3) Indexing is based on the existing indexing structure of TwitterScraper

Fetching from Index:
1) set `source=cache` to fetch data from index

Examples (First try these without source get-parameter as deployment may not have that search result): 
http://35.200.64.101/api/search.json?query=ball&scraper=quora&source=cache
http://35.200.64.101/api/search.json?query=https://www.youtube.com/watch?v=xZ-m55K3FhQ&scraper=youtube&source=cache
http://35.200.64.101/api/search.json?query=ball&scraper=quora&source=cache&count=10

I have:
- [x] There is a corresponding issue for this pull request.
- [x] Mentioned the Issue number in the pull request commit message `Fixes #<number> commit message`
- [x] There is only strictly only one commit per issue.

### For the reviewers
I have:
- [ ] Reviewed this pull request by an authorized contributor.
- [ ] The reviewer is assigned to the pull request.
