### PR TITLE
Increase Xmx for api Kubernetes image

### DIFF
--- a/kubernetes/images/api/Dockerfile
+++ b/kubernetes/images/api/Dockerfile
@@ -17,6 +17,7 @@ RUN apk update && apk add openjdk8 git bash && \
     sed -i.bak 's/^\(elasticsearch_transport.addresses\).*/\1=elasticsearch.elasticsearch:9300/' conf/config.properties && \
     sed -i.bak 's/^\(dump.write_enabled\).*/\1=false/' conf/config.properties && \
     sed -i.bak 's/^\(backend=\).*/\1http:\/\/root.loklak.org/' conf/config.properties && \
+    sed -i.bak 's/^\(Xmx\).*/\1=3G/' conf/config.properties && \
     echo "while true; do sleep 10;done" >> bin/start.sh
 
 # Start


### PR DESCRIPTION
### Short description

Fix #1516.

I've increased the Xmx to 3G. This seems to be a good configuration and staging deployment is running fine with this.

I have:
- [x] There is a corresponding issue for this pull request.
- [x] Mentioned the Issue number in the pull request commit message `Fixes #<number> commit message`
- [x] There is only strictly only one commit per issue.

### For the reviewers
I have:
- [ ] Reviewed this pull request by an authorized contributor.
- [ ] The reviewer is assigned to the pull request.
