### PR TITLE
Fixed #1576: Correct ordering of parameters of assertEquals() method in unit tests

### DIFF
--- a/test/org/loklak/api/search/InstagramProfileScraperTest.java
+++ b/test/org/loklak/api/search/InstagramProfileScraperTest.java
@@ -57,7 +57,7 @@ public class InstagramProfileScraperTest {
 				assertTrue(entry_data.has("ProfilePage"));			
 				assertTrue(config.has("viewer"));
 				assertTrue(config.has("csrf_token"));
-				assertEquals(json.getString("hostname"), hostname);
+				assertEquals(hostname, json.getString("hostname"));
 			} catch (Exception e) {
 				DAO.log("InstagramProfileScraperTest.instagramProfileScraperUserTest() assert error");
 			}

--- a/test/org/loklak/api/search/QuoraProfileScraperTest.java
+++ b/test/org/loklak/api/search/QuoraProfileScraperTest.java
@@ -56,16 +56,16 @@ public class QuoraProfileScraperTest {
         JSONArray profileList = profileListTimeLine.toArray();
         JSONObject quoraProfile = (JSONObject)profileList.get(0);
 
-        assertEquals(quoraProfile.getString("search_url"), url);
-        assertEquals(quoraProfile.getString("user_name"), userName);
-        assertEquals(quoraProfile.getString("rss_feed_link"), rssFeedLink);
-        assertEquals(quoraProfile.getString("profileImage").substring(quoraProfile.getString("profileImage").length()-profileImagePath.length()), profileImagePath);
-        assertEquals(quoraProfile.getJSONObject("feeds").getString("topics_url"), topicsUrl);
-        assertEquals(quoraProfile.getJSONObject("feeds").getString("following_url"), followingUrl);
-        assertEquals(quoraProfile.getJSONObject("feeds").getString("blogs_url"), blogsUrl);
-        assertEquals(quoraProfile.getJSONObject("feeds").getString("edits_url"), editsUrl);
-        assertEquals(quoraProfile.getJSONObject("feeds").getString("posts_url"), postsUrl);
-        assertEquals(quoraProfile.getJSONObject("feeds").getString("questions_url"), questionsUrl);
+        assertEquals(url, quoraProfile.getString("search_url"));
+        assertEquals(userName, quoraProfile.getString("user_name"));
+        assertEquals(rssFeedLink, quoraProfile.getString("rss_feed_link"));
+        assertEquals(profileImagePath, quoraProfile.getString("profileImage").substring(quoraProfile.getString("profileImage").length()-profileImagePath.length()));
+        assertEquals(topicsUrl, quoraProfile.getJSONObject("feeds").getString("topics_url"));
+        assertEquals(followingUrl, quoraProfile.getJSONObject("feeds").getString("following_url"));
+        assertEquals(blogsUrl, quoraProfile.getJSONObject("feeds").getString("blogs_url"));
+        assertEquals(editsUrl, quoraProfile.getJSONObject("feeds").getString("edits_url"));
+        assertEquals(postsUrl, quoraProfile.getJSONObject("feeds").getString("posts_url"));
+        assertEquals(questionsUrl, quoraProfile.getJSONObject("feeds").getString("questions_url"));
     }
 
     @Test
@@ -98,8 +98,8 @@ public class QuoraProfileScraperTest {
 
         for (int i = 0; i < qList.length(); i++) {
             JSONObject question = (JSONObject)qList.get(i);
-            assertEquals(question.getString("post_type"), postType);
-            assertEquals(question.getString("search_url"), url);
+            assertEquals(postType, question.getString("post_type"));
+            assertEquals(url, question.getString("search_url"));
         }
     }
 }

--- a/test/org/loklak/harvester/TwitterScraperTest.java
+++ b/test/org/loklak/harvester/TwitterScraperTest.java
@@ -140,17 +140,17 @@ public class TwitterScraperTest {
         TwitterTweet tweet = (TwitterTweet) ftweet_list.iterator().next();
 
         assertThat(String.valueOf(tweet.getUser()), containsString(tweet_check.get("user")));
-        assertEquals(String.valueOf(tweet.getStatusIdUrl()), tweet_check.get("status_id_url"));
+        assertEquals(tweet_check.get("status_id_url"), String.valueOf(tweet.getStatusIdUrl()));
 
         String created_date = dateFormatChange(String.valueOf(tweet.getCreatedAt()));
         assertThat(created_date, is(tweet_check.get("created_at")));
 
-        assertEquals(tweet.getScreenName(), tweet_check.get("screen_name"));
-        assertEquals(String.valueOf(tweet.getSourceType()), tweet_check.get("source_type"));
-        assertEquals(String.valueOf(tweet.getProviderType()), tweet_check.get("provider_type"));
-        assertEquals(tweet.getText(), tweet_check.get("text"));
-        assertEquals(tweet.getPlaceId(), tweet_check.get("place_name"));
-        assertEquals(tweet.getPlaceName(), tweet_check.get("place_id"));
+        assertEquals(tweet_check.get("screen_name"), tweet.getScreenName());
+        assertEquals(tweet_check.get("source_type"), String.valueOf(tweet.getSourceType()));
+        assertEquals(tweet_check.get("provider_type"), String.valueOf(tweet.getProviderType()));
+        assertEquals(tweet_check.get("text"), tweet.getText());
+        assertEquals(tweet_check.get("place_name"), tweet.getPlaceId());
+        assertEquals(tweet_check.get("place_id"), tweet.getPlaceName());
 
         try {
             // Other parameters of twittertweet(used )


### PR DESCRIPTION
### Short description
I have:
- [X] There is a corresponding issue for this pull request.
- [X] Mentioned the Issue number in the pull request commit message `Fixes #<number> commit message`
- [X] There is only strictly only one commit per issue.

### For the reviewers
I have:
- [ ] Reviewed this pull request by an authorized contributor.
- [ ] The reviewer is assigned to the pull request.

Fixes: #1576 