### PR TITLE
Removed some redundancy on Interfaces access modifier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ bin/log4j2.properties
 bin/api_test.sh
 .sts4-cache/
 .vscode/
+
+# Not needed for repository directory.
+/out

--- a/src/org/json/JSONString.java
+++ b/src/org/json/JSONString.java
@@ -14,5 +14,5 @@ public interface JSONString {
      *
      * @return A strictly syntactically correct JSON text.
      */
-    public String toJSONString();
+    String toJSONString();
 }

--- a/src/org/loklak/data/IndexFactory.java
+++ b/src/org/loklak/data/IndexFactory.java
@@ -31,28 +31,28 @@ import org.loklak.objects.SourceType;
 
 public interface IndexFactory<Entry extends ObjectEntry> {
 
-    public Entry init(JSONObject json) throws IOException;
+    Entry init(JSONObject json) throws IOException;
 
-    public boolean exists(String id);
-    
-    public boolean existsCache(String id);
-    
-    public Set<String> existsBulk(Collection<String> ids);
-    
-    public boolean delete(String id, SourceType sourceType);
+    boolean exists(String id);
 
-    public JSONObject readJSON(String id);
+    boolean existsCache(String id);
     
-    public JSONObject readJSONCache(String id);
-
-    public boolean writeEntry(IndexEntry<Entry> entry) throws IOException;
-
-    public boolean writeEntry(JSONObject json) throws IOException;
+    Set<String> existsBulk(Collection<String> ids);
     
-    public ElasticsearchClient.BulkWriteResult writeEntries(Collection<IndexEntry<Entry>> entries) throws IOException;
+    boolean delete(String id, SourceType sourceType);
 
-    public ElasticsearchClient.BulkWriteResult writeEntries(List<Post> entries) throws IOException;
+    JSONObject readJSON(String id);
     
-    public void close();
+    JSONObject readJSONCache(String id);
+
+    boolean writeEntry(IndexEntry<Entry> entry) throws IOException;
+
+    boolean writeEntry(JSONObject json) throws IOException;
+    
+    ElasticsearchClient.BulkWriteResult writeEntries(Collection<IndexEntry<Entry>> entries) throws IOException;
+
+    ElasticsearchClient.BulkWriteResult writeEntries(List<Post> entries) throws IOException;
+    
+    void close();
     
 }

--- a/src/org/loklak/geo/GeoPoint.java
+++ b/src/org/loklak/geo/GeoPoint.java
@@ -1,23 +1,23 @@
 /**
- *  GeoPoint
- *  Copyright 2009 by Michael Peter Christen; mc@yacy.net, Frankfurt a. M., Germany
- *  first published 08.10.2009 on http://yacy.net
- *
- *  This file is part of YaCy Content Integration
- *
- *  This library is free software; you can redistribute it and/or
- *  modify it under the terms of the GNU Lesser General Public
- *  License as published by the Free Software Foundation; either
- *  version 2.1 of the License, or (at your option) any later version.
- *
- *  This library is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- *  Lesser General Public License for more details.
- *
- *  You should have received a copy of the GNU Lesser General Public License
- *  along with this program in the file lgpl21.txt
- *  If not, see <http://www.gnu.org/licenses/>.
+ * GeoPoint
+ * Copyright 2009 by Michael Peter Christen; mc@yacy.net, Frankfurt a. M., Germany
+ * first published 08.10.2009 on http://yacy.net
+ * <p>
+ * This file is part of YaCy Content Integration
+ * <p>
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * <p>
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * <p>
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program in the file lgpl21.txt
+ * If not, see <http://www.gnu.org/licenses/>.
  */
 
 package org.loklak.geo;
@@ -30,44 +30,44 @@ package org.loklak.geo;
  */
 public interface GeoPoint {
 
-    public static final double meter = 90.0d / 1.0e7d; // this is actually the definition of 'meter': 10 million meter shall be the distance from the equator to the pole
+    static final double meter = 90.0d / 1.0e7d; // this is actually the definition of 'meter': 10 million meter shall be the distance from the equator to the pole
 
     /**
      * get the latitude of the point
      * @return
      */
-    public double lat();
+    double lat();
 
     /**
      * get the longitude of the point
      * @return
      */
-    public double lon();
+    double lon();
 
     /**
      * get the implementation-dependent accuracy of the latitude
      * @return
      */
-    public double accuracyLat();
+    double accuracyLat();
 
     /**
      * get the implementation-dependent accuracy of the longitude
      * @return
      */
-    public double accuracyLon();
+    double accuracyLon();
 
     /**
      * compute the hash code of a coordinate
      * this produces identical hash codes for locations that are close to each other
      */
     @Override
-    public int hashCode();
+    int hashCode();
 
     /**
      * equality test that is needed to use the class inside HashMap/HashSet
      */
     @Override
-    public boolean equals(final Object o);
+    boolean equals(final Object o);
 
     /**
      * compute the distance between two points using the Haversine Algorithm
@@ -75,13 +75,13 @@ public interface GeoPoint {
      * @param othr the other point
      * @return the distance of this point and the other point in meter
      */
-    public double distance(final GeoPoint othr);
+    double distance(final GeoPoint othr);
 
     /**
      * printout format of the point
      * @return
      */
     @Override
-    public String toString();
+    String toString();
 
 }

--- a/src/org/loklak/http/CookieRequest.java
+++ b/src/org/loklak/http/CookieRequest.java
@@ -1,7 +1,9 @@
 package org.loklak.http;
 
 public interface CookieRequest {
-	public CookieRequest makeRequest();
-	public String body();
-	public String cookie();
+    CookieRequest makeRequest();
+
+    String body();
+
+    String cookie();
 }

--- a/src/org/loklak/objects/ObjectEntry.java
+++ b/src/org/loklak/objects/ObjectEntry.java
@@ -23,10 +23,10 @@ import org.json.JSONObject;
 
 public interface ObjectEntry {
 
-    public String toString();
+    String toString();
     
     // TODO: convert to elasticsearch internal format directly
     
-    public JSONObject toJSON();
+    JSONObject toJSON();
     
 }

--- a/src/org/loklak/server/APIHandler.java
+++ b/src/org/loklak/server/APIHandler.java
@@ -23,14 +23,14 @@ import org.json.JSONObject;
 
 public interface APIHandler {
 
-    public String[] getServerProtocolHostStub();
+    String[] getServerProtocolHostStub();
 
-    public BaseUserRole getMinimalBaseUserRole();
+    BaseUserRole getMinimalBaseUserRole();
 
-    public JSONObject getDefaultPermissions(BaseUserRole baseUserRole);
+    JSONObject getDefaultPermissions(BaseUserRole baseUserRole);
     
-    public String getAPIPath();
+    String getAPIPath();
 
-    public JSONObject[] service(Query call, Authorization rights) throws APIException;
+    JSONObject[] service(Query call, Authorization rights) throws APIException;
     
 }

--- a/src/org/loklak/tools/storage/JsonFactory.java
+++ b/src/org/loklak/tools/storage/JsonFactory.java
@@ -25,6 +25,6 @@ import org.json.JSONObject;
 
 public interface JsonFactory {
 
-    public JSONObject getJSON() throws IOException;
+    JSONObject getJSON() throws IOException;
     
 }

--- a/src/org/loklak/tools/storage/JsonReader.java
+++ b/src/org/loklak/tools/storage/JsonReader.java
@@ -23,12 +23,12 @@ import org.loklak.tools.storage.JsonRandomAccessFile.JsonHandle;
 
 public interface JsonReader extends Runnable {
 
-    public final static JsonFactory POISON_JSON_MAP = new JsonHandle(null, -1, -1);
+    final static JsonFactory POISON_JSON_MAP = new JsonHandle(null, -1, -1);
     
-    public int getConcurrency();
+    int getConcurrency();
     
-    public JsonFactory take() throws InterruptedException;
+    JsonFactory take() throws InterruptedException;
     
-    public String getName();
+    String getName();
     
 }


### PR DESCRIPTION
By looking at all of the interfaces I saw inconsistency in to the modifier. 
We all know that by default, interface has public modifier on it methods. 
That is removed in all of them.