### PR TITLE
fix upgrade time cannot beyond 24 days

### DIFF
--- a/conf/config.properties
+++ b/conf/config.properties
@@ -106,7 +106,7 @@ peername=anonymous
 
 # a loklak instance can upgrade itself, by default every 24 hours
 # if an automatic update is not wanted, set this to i.e. ten years
-upgradeInterval = 86400000
+upgradeInterval = 24
 
 # settings to prevent DoS
 DoS.blackout = 100

--- a/src/org/loklak/LoklakServer.java
+++ b/src/org/loklak/LoklakServer.java
@@ -143,6 +143,7 @@ import org.loklak.server.HttpsMode;
 import org.loklak.stream.StreamServlet;
 import org.loklak.tools.Browser;
 import org.loklak.tools.OS;
+import org.loklak.tools.DateParser;
 
 
 public class LoklakServer {
@@ -308,7 +309,7 @@ public class LoklakServer {
 
 
         // read upgrade interval
-        Caretaker.upgradeTime = Caretaker.startupTime + DAO.getConfig("upgradeInterval", 86400000);
+        Caretaker.upgradeTime = Caretaker.startupTime + DAO.getConfig("upgradeInterval", 24) * DateParser.HOUR_MILLIS;
 
         // if this is not headless, we can open a browser automatically
         Browser.openBrowser("http://127.0.0.1:" + httpPort + "/");


### PR DESCRIPTION
### Short description
config upgradeInterval is int type and time unit is ms, the max signed integer in java is 2,147,483,647 wihich max upgradeInterval is 24 days. if you want upgradeInterval is ten years, it cannot config. So I change upgradeInterval unit to hours.
