### PR TITLE
Fix TwitterScraperTest

### DIFF
--- a/test/org/loklak/harvester/TwitterScraperTest.java
+++ b/test/org/loklak/harvester/TwitterScraperTest.java
@@ -9,6 +9,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Locale;
 import java.time.ZonedDateTime;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
@@ -191,7 +192,7 @@ public class TwitterScraperTest {
         String k;
 
         DateTimeFormatter input_format =
-                DateTimeFormatter.ofPattern("EEE MMM dd HH:mm:ss zzz yyyy");
+                DateTimeFormatter.ofPattern("EEE MMM dd HH:mm:ss zzz yyyy",new Locale("en"));
         DateTimeFormatter output_format =
                 DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
 


### PR DESCRIPTION
To fix an error:
org.loklak.harvester.TwitterScraperTest > testSimpleSearch FAILED
    java.time.format.DateTimeParseException at TwitterScraperTest.java:198

org.loklak.TestRunner > org.loklak.harvester.TwitterScraperTest.testSimpleSearch FAILED
    java.time.format.DateTimeParseException at TwitterScraperTest.java:198

